### PR TITLE
Run helper setup as Node, not GUI Electron

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1034,12 +1034,14 @@ async function runProcess(
 	args: string[],
 	timeoutMs: number,
 	signal?: AbortSignal,
+	env?: NodeJS.ProcessEnv,
 ): Promise<void> {
 	throwIfAborted(signal);
 
 	await new Promise<void>((resolve, reject) => {
 		const child = spawn(command, args, {
 			stdio: ["ignore", "pipe", "pipe"],
+			env,
 		});
 
 		let stderr = "";
@@ -1099,7 +1101,14 @@ async function ensureHelperInstalled(signal?: AbortSignal): Promise<void> {
 		return;
 	}
 
-	await runProcess(process.execPath, [SETUP_HELPER_SCRIPT, "--runtime"], HELPER_SETUP_TIMEOUT_MS, signal);
+	// process.execPath may be an Electron binary when this module runs inside an
+	// Electron main process. Force ELECTRON_RUN_AS_NODE so the helper script runs
+	// as plain Node instead of launching a GUI Electron app (which adds a dock
+	// icon and never exits). No-op for a regular Node executable.
+	await runProcess(process.execPath, [SETUP_HELPER_SCRIPT, "--runtime"], HELPER_SETUP_TIMEOUT_MS, signal, {
+		...process.env,
+		ELECTRON_RUN_AS_NODE: "1",
+	});
 	runtimeState.helperInstallChecked = true;
 
 	if (!(await isExecutable(HELPER_STABLE_PATH))) {


### PR DESCRIPTION
## Problem

When `pi-computer-use` runs inside an Electron main process (e.g. an Electron desktop app or native test lane), `process.execPath` is the **Electron** binary. `ensureHelperInstalled` spawns it to run `setup-helper.mjs --runtime`:

```ts
await runProcess(process.execPath, [SETUP_HELPER_SCRIPT, "--runtime"], ...);
```

Without `ELECTRON_RUN_AS_NODE`, that boots a **full GUI Electron app**:
- adds a (generic, unbranded) dock icon
- never exits — there's no `app.quit()` and the Electron event loop keeps running

So every helper-install check leaks another stray Electron process. After a test session the dock fills with Electron icons and the processes pile up.

## Fix

Thread an optional `env` into `runProcess` and pass `ELECTRON_RUN_AS_NODE=1` for the self-spawn so the helper runs as plain Node. No-op when `process.execPath` is a regular Node executable. Other `runProcess` callers (osascript) are unchanged (inherit env).

## Verification

- `tsc -p tsconfig.json` passes.
- Confirmed the leaked processes were `Electron .../setup-helper.mjs --runtime` (19 strays in a single session) before the fix.