### PR TITLE
fix(macos): resolve roots by stored identity

### DIFF
--- a/native/macos/bridge.swift
+++ b/native/macos/bridge.swift
@@ -1280,7 +1280,7 @@ final class Bridge {
 		let pid: Int32
 		if let windowId, let ownerPid = pidForWindowId(windowId) {
 			pid = ownerPid
-		} else if let windowRef, let element = refStore.element(for: windowRef), let owner = pidForElement(element) {
+		} else if let requestedRoot, let owner = pidForElement(requestedRoot) {
 			pid = owner
 		} else {
 			throw BridgeFailure(message: "Root is not owned by a running app", code: "root_not_found")
@@ -3168,10 +3168,20 @@ final class Bridge {
 	}
 
 	private func windowInfo(windowId: UInt32) -> (pid: Int32, bounds: CGRect)? {
-		guard let entries = CGWindowListCopyWindowInfo([.optionIncludingWindow], CGWindowID(windowId)) as? [[String: Any]],
-			let first = entries.first,
-			let pid = (first[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
-			let boundsDict = first[kCGWindowBounds as String] as? [String: Any],
+		func matchingEntry(_ entries: [[String: Any]]?) -> [String: Any]? {
+			entries?.first {
+				($0[kCGWindowNumber as String] as? NSNumber)?.uint32Value == windowId
+			}
+		}
+
+		let requestedIds = [NSNumber(value: windowId)] as CFArray
+		let targetedEntries = CGWindowListCreateDescriptionFromArray(requestedIds) as? [[String: Any]]
+		let entry = matchingEntry(targetedEntries) ?? matchingEntry(
+			CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]]
+		)
+		guard let entry,
+			let pid = (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+			let boundsDict = entry[kCGWindowBounds as String] as? [String: Any],
 			let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary)
 		else {
 			return nil

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -212,6 +212,15 @@ check("INV-18 consolidated actions and diff-first resulting views", () => {
 	assert(!ts.includes("preserveFocus") && macBackend.includes("preserveFocus") && swift.includes("!preserveFocus"), "native focus continuity leaks through the coordinator or is not enforced by the backend");
 });
 
+check("INV-19 macOS root identity resolution", () => {
+	assert(swift.includes("let requestedRoot = windowRef.flatMap { refStore.window(for: $0) }"), "look does not resolve native root refs from the window store");
+	assert(swift.includes("else if let requestedRoot, let owner = pidForElement(requestedRoot)"), "look cannot recover the owner pid from a stored native root");
+	assert(!swift.includes("CGWindowListCopyWindowInfo([.optionIncludingWindow]"), "window lookup uses optionIncludingWindow without an above/below selector");
+	assert(swift.includes("CGWindowListCreateDescriptionFromArray(requestedIds)"), "window lookup does not use the targeted window-description API");
+	assert(swift.includes("CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID)"), "window lookup does not fall back to all onscreen and offscreen windows");
+	assert(swift.includes("($0[kCGWindowNumber as String] as? NSNumber)?.uint32Value == windowId"), "window lookup does not verify the returned stable ID");
+});
+
 check("INV-8 swift typecheck", () => {
 	const triple = process.arch === "x64" ? "x86_64-apple-macosx14.0" : "arm64-apple-macosx14.0";
 	execFileSync("xcrun", [


### PR DESCRIPTION
## problem

`find_roots` can return a valid macOS root that `observe_ui` then rejects with `Root is not owned by a running app`.

There are two independent resolution failures:

- roots are inserted with `AXRefStore.storeWindow`, but the PID fallback reads the element store with `element(for:)`, so it can never recover a saved root;
- `windowInfo()` passes `.optionIncludingWindow` by itself. Apple documents that this option must be combined with `.optionOnScreenAboveWindow` or `.optionOnScreenBelowWindow` to produce meaningful results ([`optionIncludingWindow`](https://developer.apple.com/documentation/coregraphics/cgwindowlistoption/optionincludingwindow)).

## fix

- resolve the PID fallback from the already-loaded window root and use `AXUIElementGetPid` ([Apple API reference](https://developer.apple.com/documentation/applicationservices/1460337-axuielementgetpid));
- use `CGWindowListCreateDescriptionFromArray` as the targeted lookup. Apple defines it specifically for retrieving information about supplied window IDs and notes that closed windows may disappear between ID discovery and lookup ([function documentation](https://developer.apple.com/documentation/coregraphics/cgwindowlistcreatedescriptionfromarray(_:)));
- if that targeted API returns no matching dictionary, query `.optionAll` with `kCGNullWindowID` and explicitly match `kCGWindowNumber`. Apple documents that `.optionAll` includes onscreen and offscreen windows and requires the null relative ID ([`optionAll`](https://developer.apple.com/documentation/coregraphics/cgwindowlistoption/optionall));
- add a static invariant covering the stored-root path, targeted lookup, broader fallback, and ID verification.

## validation

- `npm test`
- native arm64 helper build via `node scripts/build-native.mjs --output /tmp/pi-computer-use-issue-23-targeted-bridge --no-sign`
- `git diff --check`

closes #23
