### PR TITLE
feat(core): bound output and simplify tool contracts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ Example:
 ```json
 {
   "browser_use": true,
+  "managed_browser": "helium",
   "headless": false,
   "cursor_overlay": true
 }
@@ -39,6 +40,12 @@ Default: `true`
 When `false`, the extension refuses known browser windows. This is useful for projects that should not control browsers.
 
 Known browser families include Safari, Chrome and Chromium-family browsers, Firefox, Arc, Brave, Edge, Vivaldi, and Helium.
+
+### `managed_browser`
+
+Default: `"helium"`
+
+Selects `"helium"` or `"chrome"` for `launch_browser`. The debugging port is always allocated internally and isn't part of the model-facing contract.
 
 ### `headless`
 
@@ -57,6 +64,8 @@ When `true`, macOS pointer actions enqueue a click-through agent cursor animatio
 ```bash
 PI_COMPUTER_USE_BROWSER_USE=0
 PI_COMPUTER_USE_BROWSER_USE=1
+PI_COMPUTER_USE_MANAGED_BROWSER=helium
+PI_COMPUTER_USE_MANAGED_BROWSER=chrome
 PI_COMPUTER_USE_HEADLESS=0
 PI_COMPUTER_USE_HEADLESS=1
 PI_COMPUTER_USE_CURSOR_OVERLAY=0
@@ -66,16 +75,12 @@ PI_COMPUTER_USE_DELIVERY_POLICY=foreground
 PI_COMPUTER_USE_CDP_PORT=9222
 ```
 
-`PI_COMPUTER_USE_HEADLESS=1` prohibits foreground fallback. `PI_COMPUTER_USE_DELIVERY_POLICY` is a debugging input; normal callers should use `headless`.
+`PI_COMPUTER_USE_HEADLESS=1` prohibits foreground fallback. `PI_COMPUTER_USE_DELIVERY_POLICY` is a debugging input; normal policy belongs in configuration rather than individual model calls.
 
 ## CDP browser support
 
 `PI_COMPUTER_USE_CDP_PORT` enables Chrome DevTools Protocol support for Chromium-family browsers. Launch the browser with `--remote-debugging-port=<port>` and set this variable to the same port.
 
-When CDP is active:
-
-- `navigate_browser` uses CDP navigation when possible.
-- Browser console messages are attached to relevant tool results.
-- The desktop observe/act tools still work for browser windows.
+When CDP is active, discovered pages participate in the same root and state system as desktop UI. `launch_browser` configures CDP automatically and returns an observed page state. `navigate_browser` and `evaluate_browser` accept only CDP browser-page states; native browser windows continue to use the normal desktop observe/act tools.
 
 With the variable unset, CDP is inactive.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ Example:
 ```json
 {
   "browser_use": true,
-  "managed_browser": "helium",
+  "managed_browser": "chrome",
   "headless": false,
   "cursor_overlay": true
 }
@@ -43,7 +43,7 @@ Known browser families include Safari, Chrome and Chromium-family browsers, Fire
 
 ### `managed_browser`
 
-Default: `"helium"`
+Default: `"chrome"`
 
 Selects `"helium"` or `"chrome"` for `launch_browser`. The debugging port is always allocated internally and isn't part of the model-facing contract.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,15 +11,15 @@ The normal loop is:
 
 | Tool | Purpose |
 | --- | --- |
-| `find_roots` | Find desktop and CDP browser-page roots. |
-| `observe_ui` | Capture one root and return a folded outline plus `stateId`. |
-| `search_ui` | Search the full cached outline. |
+| `find_roots` | Return a bounded, ranked set of desktop and CDP browser-page roots. |
+| `observe_ui` | Capture the current/frontmost root or one exact `@r` root and return a folded outline plus `stateId`. |
+| `search_ui` | Run a bounded, ranked query over the full cached outline. |
 | `expand_ui` | Show local outline context for one ref. |
 | `inspect_ui` | Show fields, rects, actions, and evidence for one ref. |
 | `act_ui` | Perform checked actions and return the resulting saved state, showing its changes or a full view when needed. |
-| `read_text` | Page through long text owned by a state. |
-| `wait_for` | Wait for text or a role to appear or disappear. |
-| `launch_browser` | Start a managed CDP browser and return page roots. |
+| `read_text` | Read fixed pages from state-owned `@e` text or immutable `@o` output. |
+| `wait_for` | Wait for a precise, optionally scoped condition. |
+| `launch_browser` | Start a managed CDP browser and return its observed page state. |
 | `navigate_browser` | Navigate the browser page owned by a state. |
 | `evaluate_browser` | Evaluate JavaScript in the browser page owned by a state. |
 
@@ -28,6 +28,8 @@ The normal loop is:
 `find_roots` returns roots such as `@r1`. Every desktop window, transient surface, and CDP page participates in that same forest. `observe_ui` returns element refs such as `@e12` and a `stateId`.
 
 Every tool that consumes an `@e` ref also requires its owning `stateId`. A state remains queryable while it is in the bounded store, but a mutation from an old resource epoch is rejected as stale. `act_ui` returns the next usable `stateId`; consume it directly instead of observing again. Observe again only after an uncertain external mutation or state eviction.
+
+Truncated textual output receives an immutable session-local ref such as `@o1`. Continue it with `read_text({ ref: "@o1", offset })`; output refs don't use a UI state id. Tool-provided `@o` offsets are UTF-8 byte offsets, while `@e` text offsets count Unicode characters.
 
 Nodes marked `pictureOnly` have visual evidence but no platform accessibility element. Semantic actions cannot target them. Coordinate actions are available only from a current image-bearing desktop state.
 
@@ -41,7 +43,7 @@ expand_ui({ stateId, ref: "@e7", depth: 3 })
 inspect_ui({ stateId, ref: "@e12" })
 ```
 
-`semantic` observation is cheapest, `fused` is the default, and `visual` forces visual text evidence. Search can escalate OCR once when the original desktop look omitted it; that refresh is checked against the state's resource epoch.
+`semantic` observation is cheapest, `fused` is the default, and `visual` forces visual text evidence. Search requires at least one of `text`, `role`, or `capability`. It ranks exact, prefix, and substring text before conservative fuzzy matches, returns a fixed top set with the total match count, and asks the caller to refine broad queries. Search can escalate OCR once when the original desktop look omitted it; that refresh is checked against the state's resource epoch.
 
 ## Acting and batching
 
@@ -59,15 +61,15 @@ the delivered event:
 ```js
 act_ui({
   stateId,
-  headless: true,
   actions: [{ action: "press", ref: "@e12" }],
-  expect: { text: "Archive completed", timeoutMs: 3000 }
+  expect: { text: "Archive completed", until: "present", timeoutMs: 3000 }
 })
 ```
 
 Verification reports `verified`, `preexisting`, or `failed`. A preexisting
 condition means the requested end state holds, but is not evidence that the
-action caused it.
+action caused it. Use `ref` for one exact element or `scopeRef` for a subtree;
+role-only conditions must be scoped, and value checks require an exact `ref`.
 
 Batch steps only when the second step does not need to inspect the result of the first:
 
@@ -116,19 +118,22 @@ Coordinate fallback uses image pixels from the observed state:
 act_ui({ stateId, actions: [{ action: "click", x: 420, y: 300 }] })
 ```
 
+## Bounded output
+
+Every model-visible textual result is limited to 48 KiB or 2,000 lines. Oversized results return a 16 KiB preview, focused-query guidance, and an immutable `@o` continuation. Discovery tools don't page through irrelevant matches: refine `find_roots` and `search_ui` instead. Continuation is intended for concrete long text, evaluation values, and diagnostics.
+
 ## Browser use
 
-Browser pages use the same roots, states, and element refs:
+Browser-specific commands operate only on CDP browser-page states. `launch_browser` chooses the configured browser and debugging port internally and immediately returns an observed state:
 
 ```ts
-launch_browser({ browser: "helium", url: "https://example.com" })
-find_roots({ kind: "browser_page" })
-observe_ui({ root: "@r3" })
-act_ui({ stateId, actions: [{ action: "press", ref: "@e7" }] })
+const launched = launch_browser({ url: "https://example.com" })
+act_ui({ stateId: launched.stateId, actions: [{ action: "press", ref: "@e7" }] })
 navigate_browser({ stateId: returnedStateId, url: "https://openai.com" })
+evaluate_browser({ stateId: returnedStateId, expression: "document.title" })
 ```
 
-`read_text`, `wait_for`, and `evaluate_browser` also need only the browser observation's `stateId`; there is no public `contextId` or separate snapshot flow.
+Browser states use the same outline, action, text, and condition contracts as desktop states. Native browser windows remain ordinary desktop UI; use `observe_ui` and `act_ui` rather than `navigate_browser` or `evaluate_browser` on them.
 
 ## Parallel calls
 

--- a/extensions/computer-use.ts
+++ b/extensions/computer-use.ts
@@ -19,34 +19,43 @@ import {
 import { getLoadedComputerUseConfig, loadComputerUseConfig } from "../src/config.ts";
 
 const stateId = Type.String({ description: "Required state id owning every @e ref used by this operation" });
-const root = Type.Optional(Type.String({ description: "Root ref from find_roots, e.g. @r1" }));
-const image = Type.Optional(Type.Union([Type.Literal("auto"), Type.Literal("always"), Type.Literal("never")], { description: "Image attachment mode, default auto" }));
-const refTarget = { ref: Type.Optional(Type.String({ description: "Outline ref, e.g. @e12" })), x: Type.Optional(Type.Number()), y: Type.Optional(Type.Number()) };
+const point = { x: Type.Number(), y: Type.Number() };
 const mouseButton = Type.Optional(Type.Union([Type.Literal("left"), Type.Literal("right"), Type.Literal("middle")]));
+const clickByRef = Type.Object({ action: Type.Literal("click"), ref: Type.String(), button: mouseButton, clickCount: Type.Optional(Type.Number({ minimum: 1, maximum: 3 })) });
+const clickByPoint = Type.Object({ action: Type.Literal("click"), ...point, button: mouseButton, clickCount: Type.Optional(Type.Number({ minimum: 1, maximum: 3 })) });
 const uiAction = Type.Union([
-	Type.Object({ action: Type.Literal("press"), ...refTarget }),
-	Type.Object({ action: Type.Literal("click"), ...refTarget, button: mouseButton, clickCount: Type.Optional(Type.Number()) }),
-	Type.Object({ action: Type.Literal("doubleClick"), ...refTarget, button: mouseButton }),
+	Type.Object({ action: Type.Literal("press"), ref: Type.String({ description: "Actionable outline ref" }) }),
+	clickByRef,
+	clickByPoint,
 	Type.Object({ action: Type.Literal("setText"), ref: Type.String({ description: "Editable outline ref" }), text: Type.String() }),
 	Type.Object({ action: Type.Literal("typeText"), ref: Type.Optional(Type.String({ description: "Omit after a click to type into the focus established by that click" })), text: Type.String() }),
 	Type.Object({ action: Type.Literal("keypress"), ref: Type.Optional(Type.String({ description: "Omit to send keys to the focused control" })), keys: Type.Array(Type.String(), { minItems: 1 }) }),
-	Type.Object({ action: Type.Literal("scroll"), ...refTarget, scrollX: Type.Optional(Type.Number()), scrollY: Type.Optional(Type.Number()) }),
-	Type.Object({ action: Type.Literal("drag"), path: Type.Array(Type.Object({ x: Type.Number(), y: Type.Number() }), { minItems: 2 }) }),
-	Type.Object({ action: Type.Literal("moveMouse"), ...refTarget }),
-	Type.Object({ action: Type.Literal("wait"), ms: Type.Number() }),
+	Type.Object({ action: Type.Literal("scroll"), ref: Type.Optional(Type.String()), scrollX: Type.Optional(Type.Number()), scrollY: Type.Optional(Type.Number()) }),
+	Type.Object({ action: Type.Literal("drag"), path: Type.Array(Type.Object(point), { minItems: 2 }) }),
+	Type.Object({ action: Type.Literal("moveMouse"), ...point }),
 ]);
+
+const conditionProperties = {
+	ref: Type.Optional(Type.String({ description: "Specific @e ref to test", maxLength: 128 })),
+	scopeRef: Type.Optional(Type.String({ description: "Restrict matching to this @e subtree", maxLength: 128 })),
+	text: Type.Optional(Type.String({ description: "Text that must match", maxLength: 512 })),
+	role: Type.Optional(Type.String({ description: "Exact normalized role", maxLength: 128 })),
+	value: Type.Optional(Type.String({ description: "Exact normalized value; normally pair with ref" })),
+	until: Type.Optional(Type.Union([Type.Literal("present"), Type.Literal("absent")], { description: "Desired condition, default present" })),
+	timeoutMs: Type.Optional(Type.Number({ description: "Maximum wait, default 10000ms", minimum: 100, maximum: 60000 })),
+};
 
 const findTool = defineTool({
 	name: "find_roots",
 	label: "Find Roots",
-	description: "Find controllable UI roots with refs, geometry, and focus state.",
+	description: "Find a bounded, ranked set of controllable UI roots with refs, geometry, and focus state.",
 	promptSnippet: "Find a target root before observe_ui when needed.",
 	parameters: Type.Object({
-		query: Type.Optional(Type.String({ description: "Optional app/title/menu label query; absent or unmatched returns all roots" })),
-		app: Type.Optional(Type.String({ description: "Optional app-name narrowing filter" })),
-		bundleId: Type.Optional(Type.String({ description: "Optional bundle-id narrowing filter" })),
-		pid: Type.Optional(Type.Number({ description: "Optional process-id narrowing filter" })),
-		kind: Type.Optional(Type.Union([Type.Literal("window"), Type.Literal("menu"), Type.Literal("sheet"), Type.Literal("popover"), Type.Literal("dialog"), Type.Literal("browser_page")], { description: "Optional root kind narrowing filter" })),
+		text: Type.Optional(Type.String({ description: "Ranked app or title text", maxLength: 256 })),
+		app: Type.Optional(Type.String({ description: "Exact normalized app name", maxLength: 256 })),
+		bundleId: Type.Optional(Type.String({ description: "Exact bundle id" })),
+		pid: Type.Optional(Type.Number({ description: "Exact process id" })),
+		kind: Type.Optional(Type.Union([Type.Literal("window"), Type.Literal("menu"), Type.Literal("sheet"), Type.Literal("popover"), Type.Literal("dialog"), Type.Literal("browser_page")], { description: "Exact root kind" })),
 	}),
 	execute: executeFind,
 });
@@ -54,18 +63,15 @@ const findTool = defineTool({
 const observeTool = defineTool({
 	name: "observe_ui",
 	label: "Observe UI",
-	description: "Capture one look and return the running note plus a folded UI outline with counts, ancestor refs, pictureOnly nodes, and optional image.",
+	description: "Capture the current/frontmost root or one exact @r root and return a bounded UI outline.",
 	promptSnippet: "Primary UI observation tool. Follow with search_ui, expand_ui, inspect_ui, or act_ui.",
 	promptGuidelines: [
-		"Use mode=semantic to skip OCR text, visual to force OCR text, and fused for auto OCR.",
+		"Use mode=semantic to skip OCR and images, visual to force them, and fused for automatic selection.",
 		"Use @e outline refs from observe_ui/search_ui for act_ui; pictureOnly refs are coordinate-only and blocked by UI-tree-only policy.",
 	],
 	parameters: Type.Object({
-		app: Type.Optional(Type.String({ description: "Optional app name" })),
-		windowTitle: Type.Optional(Type.String({ description: "Optional exact window title" })),
-		root,
+		root: Type.Optional(Type.String({ description: "Exact @r ref issued by find_roots" })),
 		mode: Type.Optional(Type.Union([Type.Literal("semantic"), Type.Literal("visual"), Type.Literal("fused")], { description: "Observation mode, default fused" })),
-		image,
 	}),
 	execute: executeObserve,
 });
@@ -73,13 +79,12 @@ const observeTool = defineTool({
 const searchUiTool = defineTool({
 	name: "search_ui",
 	label: "Search UI",
-	description: "Search the full cached outline by text, role, or action in document order and return ancestor paths with the current note header.",
-	promptSnippet: "Find targets not shown in the compact observe_ui output.",
+	description: "Return a bounded, deterministically ranked search of the cached outline. At least one predicate is required.",
+	promptSnippet: "Find targets not shown in the compact observe_ui output; refine broad searches instead of paging matches.",
 	parameters: Type.Object({
-		text: Type.Optional(Type.String({ description: "Text/label query" })),
-		role: Type.Optional(Type.String({ description: "Accessibility role, e.g. button" })),
-		action: Type.Optional(Type.String({ description: "Action/capability, e.g. press" })),
-		limit: Type.Optional(Type.Number({ description: "Maximum results, default 12" })),
+		text: Type.Optional(Type.String({ description: "Human-readable text or label", maxLength: 256 })),
+		role: Type.Optional(Type.String({ description: "Exact normalized role, e.g. button", maxLength: 128 })),
+		capability: Type.Optional(Type.String({ description: "Exact capability, e.g. press", maxLength: 128 })),
 		stateId,
 	}),
 	execute: executeSearchUi,
@@ -88,96 +93,73 @@ const searchUiTool = defineTool({
 const expandUiTool = defineTool({
 	name: "expand_ui",
 	label: "Expand UI",
-	description: "Unfold local outline context for one @e ref; truncated or changed note regions trigger a scoped look first.",
+	description: "Unfold bounded local outline context for one @e ref.",
 	promptSnippet: "Expand a specific ref instead of dumping unrelated UI.",
-	parameters: Type.Object({
-		ref: Type.String({ description: "Outline ref from observe_ui/search_ui, e.g. @e12" }),
-		depth: Type.Optional(Type.Number({ description: "Outline subtree depth, default 3" })),
-		stateId,
-	}),
+	parameters: Type.Object({ ref: Type.String(), depth: Type.Optional(Type.Number({ minimum: 1, maximum: 8, description: "Subtree depth, default 3" })), stateId }),
 	execute: executeExpandUi,
 });
 
 const inspectUiTool = defineTool({
 	name: "inspect_ui",
 	label: "Inspect UI",
-	description: "Inspect one outline ref with fields, image-pixel rect, actions, annotations, text boxes, and pictureOnly/truncated state.",
+	description: "Inspect one exact outline ref with fields, geometry, capabilities, and annotations.",
 	promptSnippet: "Use when a target's evidence or provenance matters.",
-	parameters: Type.Object({
-		ref: Type.String({ description: "Outline ref from observe_ui/search_ui, e.g. @e12" }),
-		includeRaw: Type.Optional(Type.Boolean({ description: "Include the serialized outline node in details" })),
-		stateId,
-	}),
+	parameters: Type.Object({ ref: Type.String(), stateId }),
 	execute: executeInspectUi,
 });
 
 const actTool = defineTool({
 	name: "act_ui",
 	label: "Act",
-	description: "Perform one or more checked actions, returning the resulting saved state and a compact list of changes when trustworthy.",
-	promptSnippet: "Pass dependent click/type steps together, use the returned state directly, and omit the typing ref when the click should establish focus.",
-	promptGuidelines: [
-		"Use expect for observable completion instead of issuing a separate observe_ui call.",
-		"After clicking an editable region, omit ref from typeText/keypress so input follows the focus established by the click.",
-	],
-	parameters: Type.Object({
-		stateId,
-		headless: Type.Optional(Type.Boolean({ description: "When true, prohibit foreground fallback. When false or omitted, Pi still attempts background first and uses foreground only after a side-effect-free foreground_required result." })),
-		expect: Type.Optional(Type.Object({
-			text: Type.Optional(Type.String({ description: "Text that must appear after the transaction" })),
-			role: Type.Optional(Type.String({ description: "Role that must appear after the transaction" })),
-			value: Type.Optional(Type.String({ description: "Exact normalized value required on the matching element" })),
-			gone: Type.Optional(Type.Boolean({ description: "When true, the matching text/role must disappear" })),
-			timeoutMs: Type.Optional(Type.Number({ description: "Maximum postcondition wait, default 10000ms" })),
-		})),
-		actions: Type.Array(uiAction, { minItems: 1, maxItems: 20 }),
-		image,
-	}),
+	description: "Perform one or more precisely targeted checked actions and return the successor state.",
+	promptSnippet: "Pass dependent click/type steps together and use expect for observable completion.",
+	promptGuidelines: ["After clicking an editable region, omit ref from typeText/keypress so input follows the established focus."],
+	parameters: Type.Object({ stateId, expect: Type.Optional(Type.Object(conditionProperties)), actions: Type.Array(uiAction, { minItems: 1, maxItems: 20 }) }),
 	execute: executeAct,
 });
 
 const readTextTool = defineTool({
 	name: "read_text",
 	label: "Read Text",
-	description: "Read text from a text-bearing desktop UI ref or browser context, with pagination.",
-	promptSnippet: "Fetch full text when observe_ui/inspect_ui shows a truncated text-bearing ref.",
-	parameters: Type.Object({ ref: Type.Optional(Type.String()), offset: Type.Optional(Type.Number()), limit: Type.Optional(Type.Number()), stateId }),
+	description: "Read a fixed-size page from an @e UI ref or immutable @o truncated-output ref.",
+	promptSnippet: "Use @e with its stateId; @o continuation refs don't need stateId.",
+	parameters: Type.Object({ ref: Type.String(), offset: Type.Optional(Type.Number({ minimum: 0 })), stateId: Type.Optional(stateId) }),
 	execute: executeReadText,
 });
 
 const waitForTool = defineTool({
 	name: "wait_for",
 	label: "Wait For",
-	description: "Wait until desktop UI or browser context text/role appears or disappears.",
-	promptSnippet: "Use after async UI changes instead of polling observe_ui.",
-	parameters: Type.Object({ text: Type.Optional(Type.String()), role: Type.Optional(Type.String()), gone: Type.Optional(Type.Boolean()), timeoutMs: Type.Optional(Type.Number()), stateId }),
+	description: "Wait for one scoped UI condition and return the successor state.",
+	promptSnippet: "Use after asynchronous UI changes instead of polling observe_ui.",
+	parameters: Type.Object({ ...conditionProperties, stateId }),
 	execute: executeWaitFor,
 });
 
 const launchBrowserTool = defineTool({
 	name: "launch_browser",
 	label: "Launch Browser Context",
-	description: "Launch a Pi-managed browser and return its controllable browser-page roots.",
-	promptSnippet: "Use for browser work that needs CDP contexts.",
-	parameters: Type.Object({ browser: Type.Optional(Type.Union([Type.Literal("helium"), Type.Literal("chrome")])), url: Type.Optional(Type.String()), port: Type.Optional(Type.Number()) }),
+	description: "Launch the configured Pi-managed CDP browser and return an observed browser-page state.",
+	promptSnippet: "Use for browser work that needs a managed CDP context.",
+	parameters: Type.Object({ url: Type.Optional(Type.String({ maxLength: 8192 })) }),
 	execute: executeLaunchBrowser,
 });
 
 const navigateBrowserTool = defineTool({
 	name: "navigate_browser",
 	label: "Navigate Browser",
-	description: "Navigate a browser window directly to a URL or search string.",
-	promptSnippet: "Use direct browser navigation instead of address-bar typing when possible.",
-	parameters: Type.Object({ url: Type.String(), stateId, image }),
+	description: "Navigate an observed CDP browser-page state to an HTTP(S) URL.",
+	promptSnippet: "Native browser windows use act_ui; this tool is CDP-only.",
+	parameters: Type.Object({ url: Type.String({ maxLength: 8192 }), stateId }),
 	execute: executeNavigateBrowser,
 });
 
 const evaluateBrowserTool = defineTool({
 	name: "evaluate_browser",
 	label: "Evaluate Browser",
-	description: "Evaluate JavaScript in a CDP-connected browser context.",
-	promptSnippet: "Use for targeted browser inspection when observe is insufficient.",
-	parameters: Type.Object({ stateId, expression: Type.String() }),
+	description: "Evaluate targeted JavaScript in a CDP browser-page state; returned output is strictly bounded.",
+	promptSnippet: "Prefer observe/search/read; return selected fields, aggregates, or bounded slices.",
+	parameters: Type.Object({ stateId, expression: Type.String({ maxLength: 65_536 }) }),
 	execute: executeEvaluateBrowser,
 });
 
@@ -186,6 +168,7 @@ function formatConfigStatus(): string {
 	return [
 		"pi-computer-use configuration",
 		`browser_use: ${loaded.config.browser_use ? "enabled" : "disabled"}`,
+		`managed_browser: ${loaded.config.managed_browser}`,
 		`headless: ${loaded.config.headless ? "enabled" : "disabled"}`,
 		`cursor_overlay: ${loaded.config.cursor_overlay ? "enabled" : "disabled"}`,
 		"",

--- a/native/macos/bridge.swift
+++ b/native/macos/bridge.swift
@@ -2263,6 +2263,7 @@ final class Bridge {
 		let text = optionalStringArg(request, "text")?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 		let expectedValue = optionalStringArg(request, "value")?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 		let waitForGone = boolArg(request, "gone") ?? false
+		let scopeExact = boolArg(request, "scopeExact") ?? false
 		let timeoutMs = max(100, min(60_000, optionalIntArg(request, "timeoutMs") ?? 10_000))
 		let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
 		guard role?.isEmpty == false || text?.isEmpty == false || expectedValue?.isEmpty == false else {
@@ -2270,6 +2271,15 @@ final class Bridge {
 		}
 		guard let window = windowElement(pid: pid, windowId: windowId, windowRef: windowRef) else {
 			return ["found": false, "reason": "window_not_found"]
+		}
+		let rootElement: AXUIElement
+		if let scopeRef = optionalStringArg(request, "scopeRef") {
+			guard let scoped = refStore.element(for: scopeRef), isElement(scoped, descendantOf: window) else {
+				throw BridgeFailure(message: "Condition scope ref is stale or outside the target root", code: "element_ref_invalid")
+			}
+			rootElement = scoped
+		} else {
+			rootElement = window
 		}
 		_ = ensureRootObserver(pid: pid)
 
@@ -2295,7 +2305,8 @@ final class Bridge {
 		var lastCount = 0
 		repeat {
 			let changeGeneration = rootChangeGeneration(pid: pid)
-			let descendants = collectDescendantsWithContext(startingAt: window, maxDepth: 12, maxNodes: 2000)
+			let collected = collectDescendantsWithContext(startingAt: rootElement, maxDepth: 12, maxNodes: 2000)
+			let descendants = scopeExact ? Array(collected.prefix(1)) : collected
 			lastCount = descendants.count
 			if let match = descendants.first(where: { matches($0.element) }) {
 				if waitForGone {

--- a/native/windows/bridge-rs/src/main.rs
+++ b/native/windows/bridge-rs/src/main.rs
@@ -1289,6 +1289,21 @@ fn handle_wait_for(args: &Value) -> Result<Value, ProtocolError> {
         .and_then(Value::as_str)
         .map(|s| s.trim().to_lowercase());
     let gone = args.get("gone").and_then(Value::as_bool).unwrap_or(false);
+    let scope_exact = args.get("scopeExact").and_then(Value::as_bool).unwrap_or(false);
+    let scope_runtime_id = match (
+        args.get("lookId").and_then(Value::as_str),
+        args.get("scopeRef").and_then(Value::as_str),
+    ) {
+        (Some(look_id), Some(scope_ref)) => Some(
+            helper_state()
+                .lock()
+                .map_err(|_| internal("helper state lock poisoned"))?
+                .element_for_look(look_id, scope_ref)?
+                .runtime_id,
+        ),
+        (None, Some(_)) => return Err(invalid("scopeRef requires lookId")),
+        _ => None,
+    };
     if text.is_none() && role.is_none() && expected_value.is_none() {
         return Err(invalid("uiaWaitFor requires text, role, or value"));
     }
@@ -1298,7 +1313,28 @@ fn handle_wait_for(args: &Value) -> Result<Value, ProtocolError> {
     while Instant::now() < deadline {
         let elements = windows_bridge::uia::live_elements(hwnd).map_err(internal)?;
         node_count = elements.len();
+        let parents: HashMap<String, String> = elements
+            .iter()
+            .filter_map(|element| {
+                let runtime = element.get("runtimeId")?.as_array()?;
+                let parent = element.get("parentRuntimeId")?.as_array()?;
+                Some((serde_json::to_string(runtime).ok()?, serde_json::to_string(parent).ok()?))
+            })
+            .collect();
+        let scope_key = scope_runtime_id.as_ref().and_then(|id| serde_json::to_string(id).ok());
         let found = elements.iter().any(|element| {
+            if let Some(scope_key) = &scope_key {
+                let Some(mut current) = element.get("runtimeId").and_then(Value::as_array).and_then(|id| serde_json::to_string(id).ok()) else { return false; };
+                let mut within_scope = false;
+                for _ in 0..64 {
+                    if &current == scope_key { within_scope = true; break; }
+                    if scope_exact { break; }
+                    let Some(parent) = parents.get(&current) else { break; };
+                    if parent == &current { break; }
+                    current = parent.clone();
+                }
+                if !within_scope { return false; }
+            }
             let candidate_text = ["value", "label", "name", "title"]
                 .iter()
                 .filter_map(|key| element.get(*key).and_then(Value::as_str))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@injaneity/pi-computer-use",
-	"version": "0.4.3",
+	"version": "0.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@injaneity/pi-computer-use",
-			"version": "0.4.3",
+			"version": "0.5.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@injaneity/pi-computer-use",
-	"version": "0.4.3",
+	"version": "0.5.0",
 	"description": "Pi extension that lets AI agents observe and control macOS and Windows apps.",
 	"type": "module",
 	"keywords": [
@@ -53,11 +53,12 @@
 		"test:invariants": "node scripts/check-invariants.mjs",
 		"test:lifecycle": "node --experimental-transform-types scripts/check-session-lifecycle.mjs",
 		"test:runtime": "node --experimental-transform-types scripts/check-runtime-concurrency.mjs",
+		"test:output": "node --experimental-transform-types scripts/check-bounded-output.mjs",
 		"test:commits": "node scripts/check-commit-messages.mjs",
 		"test:platform": "node --experimental-strip-types scripts/check-platform-windows.mjs",
 		"test:windows-scripts": "node scripts/check-windows-build-scripts.mjs",
 		"test:signing": "node scripts/check-local-signing.mjs",
-		"test": "npm run typecheck && npm run test:schema && npm run test:lifecycle && npm run test:runtime && npm run test:invariants && npm run test:signing",
+		"test": "npm run typecheck && npm run test:schema && npm run test:output && npm run test:lifecycle && npm run test:runtime && npm run test:invariants && npm run test:signing",
 		"build:native": "node scripts/build-native.mjs",
 		"build:windows": "node scripts/build-native.mjs --platform windows"
 	},

--- a/scripts/check-bounded-output.mjs
+++ b/scripts/check-bounded-output.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { applyOutputEnvelope, boundToolError, clearStoredOutputs, MODEL_TEXT_MAX_BYTES, readStoredOutput } from "../src/output.ts";
+import { searchOutlineRanked } from "../src/outline.ts";
+
+clearStoredOutputs();
+const oversized = "🙂".repeat(30_000);
+const bounded = applyOutputEnvelope("evaluate_browser", { content: [{ type: "text", text: oversized }], details: {} });
+const visible = bounded.content[0].text;
+assert.ok(Buffer.byteLength(visible, "utf8") <= MODEL_TEXT_MAX_BYTES, "model-facing text exceeds the hard ceiling");
+const ref = visible.match(/"(@o\d+)"/)?.[1];
+const offset = Number(visible.match(/offset: (\d+)/)?.[1]);
+assert.ok(ref && Number.isFinite(offset), "truncated output must provide a continuation");
+const page = readStoredOutput(ref, offset);
+assert.ok(page?.text.length, "continuation page must exist");
+assert.equal(readStoredOutput(ref, offset)?.text, page.text, "continuation pages must be immutable");
+assert.doesNotThrow(() => new TextEncoder().encode(page.text), "continuation must preserve utf-8");
+const unaligned = readStoredOutput(ref, offset + 1);
+assert.ok(unaligned && !unaligned.text.startsWith("�"), "arbitrary offsets must align to utf-8 boundaries");
+const lineBounded = applyOutputEnvelope("observe_ui", { content: [{ type: "text", text: "x\n".repeat(3_000) }], details: {} });
+assert.ok(lineBounded.content[0].text.split("\n").length <= 2_000, "model-facing text exceeds the line ceiling");
+const boundedError = boundToolError("evaluate_browser", new Error("x".repeat(100_000)));
+assert.ok(Buffer.byteLength(boundedError.message, "utf8") <= MODEL_TEXT_MAX_BYTES, "tool errors must obey the text ceiling");
+
+const node = (ref, title, role = "AXButton") => ({ ref, role, subrole: "", identifier: "", title, description: "", value: "", actions: ["AXPress"], canPress: true, canFocus: false, canSetValue: false, canScroll: false, canIncrement: false, canDecrement: false, isTextInput: false, focused: false, offscreen: false, pictureOnly: false, truncated: false, text: [], children: [] });
+const root = node("@e1", "root", "AXWindow");
+root.children = [node("@e2", "Save"), node("@e3", "Save changes"), node("@e4", "Autosave"), node("@e5", "Svae")];
+for (const child of root.children) child.parent = root;
+const outline = { lookId: "look", root, nodes: [root, ...root.children], refToWireRef: new Map(), wireRefToRef: new Map() };
+const ranked = searchOutlineRanked(outline, "save", "button", "press", 12);
+assert.deepEqual(ranked.matches.map((match) => match.matchReason), ["exact", "prefix", "substring", "fuzzy"]);
+assert.equal(ranked.totalMatches, 4);
+clearStoredOutputs();
+
+console.log("Bounded output and ranked search checks passed.");

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -91,10 +91,7 @@ function containsEditable(node: OutlineNode): boolean {
 }
 
 export function prepareAction(action: UiAction, state: ActionState, env: ActionEnvironment): PreparedAction {
-	if (action.action === "wait") {
-		return { action: "wait", params: { ms: Math.max(0, Math.min(60_000, Math.round(toFiniteNumber(action.ms, 1_000)))) }, establishesFocus: false, usesCurrentFocus: false, needsForeground: false };
-	}
-	const operation = action.action === "doubleClick" ? "click" : action.action;
+	const operation = action.action;
 	const usesCurrentFocus = !env.headless && state.currentFocus && !action.ref && (operation === "typeText" || operation === "keypress");
 	const target = usesCurrentFocus ? focusedTarget(env) : nativeTarget(action, operation, env);
 	const establishesFocus = !env.headless && Boolean(action.ref) && (operation === "click" || operation === "press") && containsEditable(env.node(action.ref!));
@@ -102,7 +99,7 @@ export function prepareAction(action: UiAction, state: ActionState, env: ActionE
 
 	switch (operation) {
 		case "press":
-		case "click": return { action: operation, target, params: { button: mouseButton(action.button), clickCount: action.action === "doubleClick" ? 2 : clickCount(action.clickCount) }, establishesFocus, usesCurrentFocus: false, needsForeground };
+		case "click": return { action: operation, target, params: { button: mouseButton(action.button), clickCount: clickCount(action.clickCount) }, establishesFocus, usesCurrentFocus: false, needsForeground };
 		case "setText": return { action: operation, target, params: { text: action.text ?? "" }, establishesFocus: false, usesCurrentFocus: false, needsForeground: false };
 		case "typeText": return { action: operation, target, params: { text: action.text ?? "" }, establishesFocus: false, usesCurrentFocus, needsForeground: false };
 		case "keypress": return { action: operation, target, params: { keys: keys(action.keys) }, establishesFocus: false, usesCurrentFocus, needsForeground: false };
@@ -127,8 +124,7 @@ export function outcomeAfterObservedValues(
 	actions: UiAction[],
 	valueForRef: (ref: string) => string | undefined,
 ): "worked" | "didnt" | "unknown" {
-	const meaningful = actions.filter((action) => action.action !== "wait");
-	if (meaningful.length === 0 || meaningful.some((action) => action.action !== "setText" || !action.ref)) return current;
-	const matches = meaningful.every((action) => valueForRef(action.ref!) === (action.text ?? ""));
+	if (actions.length === 0 || actions.some((action) => action.action !== "setText" || !action.ref)) return current;
+	const matches = actions.every((action) => valueForRef(action.ref!) === (action.text ?? ""));
 	return matches ? "worked" : current;
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,10 +7,11 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { canRetryInForeground, outcomeAfterCheck, outcomeAfterObservedValues, prepareAction, type ActionState, type PreparedAction } from "./actions.ts";
-import { cdpClickForContext, cdpEvaluateForContext, cdpNavigateContext, cdpScrollForContext, cdpSnapshotForContext, cdpTabForWindow, cdpTypeForContext, disconnectCdp, listCdpPageContexts, type CdpConsoleEntry, type CdpPageSnapshot } from "./cdp.ts";
+import { cdpClickForContext, cdpDragForContext, cdpEvaluateForContext, cdpKeypressForContext, cdpMouseForContext, cdpNavigateContext, cdpScrollForContext, cdpSnapshotForContext, cdpTabForWindow, cdpTypeFocusedForContext, cdpTypeForContext, disconnectCdp, listCdpPageContexts, type CdpConsoleEntry, type CdpPageSnapshot } from "./cdp.ts";
 import { getComputerUseConfig, isBrowserUseEnabled, isHeadlessMode, loadComputerUseConfig } from "./config.ts";
 import { noteAfterAct, noteFromLook, noteRegionKeyForRef, renderNote, type WindowNote } from "./note.ts";
-import { foldToBudget, graftScopedOutline, nodeByRef, outlineNodeLabel, outlineNodePath, restoreOutline, searchOutline, serializeOutline, serializeOutlineNode, type LookResponse, type Outline, type OutlineChange, type OutlineNode, type OutlineSearchMatch, type SerializedOutline, type SerializedOutlineNode } from "./outline.ts";
+import { foldToBudget, graftScopedOutline, nodeByRef, outlineNodeLabel, outlineNodePath, rankedTextMatch, restoreOutline, searchOutline, searchOutlineRanked, serializeOutline, serializeOutlineNodeShallow, type LookResponse, type Outline, type OutlineChange, type OutlineNode, type OutlineSearchMatch, type SerializedOutline, type SerializedOutlineNode } from "./outline.ts";
+import { applyOutputEnvelope, boundToolError, clearStoredOutputs, OUTPUT_PAGE_BYTES, readStoredOutput, UI_TEXT_PAGE_CHARS } from "./output.ts";
 import { AGENT_TOOL_NAMES, type ActParams, type EvaluateBrowserParams, type ExpandUiParams, type ImageMode, type InspectUiParams, type LaunchBrowserParams, type FindParams, type MouseButtonName, type NavigateBrowserParams, type ObserveParams, type ObserveTargetParams, type ReadTextParams, type RootSelector, type SearchUiParams, type StateTargetParams, type UiAction, type WaitForParams } from "./contract.ts";
 import { toFiniteNumber } from "./platform/coerce.ts";
 import { currentPlatformBackend } from "./platform/index.ts";
@@ -122,6 +123,9 @@ interface ComputerUseDetails {
 interface ListWindowsDetails {
 	tool: "find_roots";
 	query: FindParams;
+	totalMatches?: number;
+	returned?: number;
+	hasMore?: boolean;
 	windows: Array<{
 		app: string;
 		bundleId?: string;
@@ -173,15 +177,6 @@ interface EvaluateBrowserDetails {
 	changes?: OutlineChange[];
 	outline: SerializedOutline;
 	renderedOutline: string;
-	value: unknown;
-}
-
-interface LaunchBrowserDetails {
-	tool: "launch_browser";
-	browser: "helium" | "chrome";
-	port: number;
-	url: string;
-	roots: Array<{ ref: string; kind: "browser_page"; title: string; url: string }>;
 }
 
 interface ReadTextDetails {
@@ -189,8 +184,10 @@ interface ReadTextDetails {
 	ref?: string;
 	offset: number;
 	limit: number;
-	totalChars: number;
+	totalChars?: number;
+	totalBytes?: number;
 	hasMore: boolean;
+	complete?: boolean;
 	text: string;
 }
 
@@ -207,6 +204,8 @@ interface WaitForDetails {
 	nodeCount?: number;
 	text?: string;
 	role?: string;
+	value?: string;
+	scopeRef?: string;
 	outline: SerializedOutline;
 	renderedOutline: string;
 }
@@ -217,9 +216,11 @@ interface OutlineToolDetails {
 	lookId?: string;
 	outline?: SerializedOutline;
 	renderedOutline?: string;
+	totalMatches?: number;
+	returned?: number;
+	hasMore?: boolean;
 	matches?: Array<Omit<OutlineSearchMatch, "node"> & { node?: SerializedOutlineNode }>;
 	target?: SerializedOutlineNode;
-	raw?: unknown;
 	note?: WindowNote;
 }
 
@@ -278,7 +279,7 @@ const BROWSER_CONTEXT_PREFIX = "browser:";
 const MANAGED_BROWSER_READY_TIMEOUT_MS = 15_000;
 const AUTO_IMAGE_MAX_DIMENSION = 900;
 const EXPLICIT_IMAGE_MAX_DIMENSION = 1_600;
-const BROWSER_TRANSACTION_ACTIONS = new Set<UiAction["action"]>(["press", "click", "setText", "scroll"]);
+const BROWSER_TRANSACTION_ACTIONS = new Set<UiAction["action"]>(["press", "click", "setText", "typeText", "keypress", "scroll", "drag", "moveMouse"]);
 const HELIUM_EXECUTABLE = "/Applications/Helium.app/Contents/MacOS/Helium";
 const CHROME_EXECUTABLE = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 
@@ -329,6 +330,7 @@ export async function shutdownComputerUseSession(): Promise<void> {
 	runtimeState.previousCdpPort = undefined;
 
 	savedStates.clear();
+	clearStoredOutputs();
 	runtimeState.windowRefs.clear();
 	runtimeState.windowRefByIdentity.clear();
 	runtimeState.browserRootByContext.clear();
@@ -581,10 +583,6 @@ async function listWindows(pid: number, signal?: AbortSignal): Promise<HelperWin
 	return await currentPlatformBackend.listRoots({ pid }, signal);
 }
 
-async function listWindowsByTitle(title: string, signal?: AbortSignal): Promise<HelperWindow[]> {
-	return await currentPlatformBackend.listRoots({ title }, signal);
-}
-
 function appMatchesWindowQuery(app: HelperApp, query: FindParams): boolean {
 	const appQuery = trimOrUndefined(query.app);
 	const bundleQuery = trimOrUndefined(query.bundleId);
@@ -592,7 +590,7 @@ function appMatchesWindowQuery(app: HelperApp, query: FindParams): boolean {
 
 	if (pidQuery !== undefined && app.pid !== pidQuery) return false;
 	if (bundleQuery && normalizeText(app.bundleId ?? "") !== normalizeText(bundleQuery)) return false;
-	if (appQuery && !normalizeText(app.appName).includes(normalizeText(appQuery))) return false;
+	if (appQuery && normalizeText(app.appName) !== normalizeText(appQuery)) return false;
 	return true;
 }
 
@@ -769,54 +767,6 @@ function chooseRankedWindowOrUndefined(windows: HelperWindow[]): HelperWindow | 
 	const topScore = scoreWindow(ranked[0]);
 	const nextScore = scoreWindow(ranked[1]);
 	return topScore >= nextScore + 25 ? ranked[0] : undefined;
-}
-
-function chooseAppByQuery(apps: HelperApp[], appQuery: string): HelperApp {
-	const query = normalizeText(appQuery);
-	const exactMatches = apps.filter((app) => normalizeText(app.appName) === query);
-	if (exactMatches.length === 1) return exactMatches[0];
-	if (exactMatches.length > 1) {
-		return exactMatches.find((app) => app.isFrontmost) ?? exactMatches[0];
-	}
-
-	const partialMatches = apps.filter((app) => normalizeText(app.appName).includes(query));
-	if (partialMatches.length === 0) {
-		const running = apps.slice(0, 12).map((app) => app.appName).join(", ");
-		throw new Error(`App '${appQuery}' is not running. Running apps: ${running || "none"}.`);
-	}
-	if (partialMatches.length === 1) {
-		return partialMatches[0];
-	}
-
-	const candidates = partialMatches.map((app) => app.appName).join(", ");
-	throw new Error(`App name '${appQuery}' is ambiguous (${candidates}). Use a more specific app name.`);
-}
-
-function chooseWindowByTitle(windows: HelperWindow[], windowTitle: string, appName: string): HelperWindow {
-	const query = normalizeText(windowTitle);
-	const exactMatches = windows.filter((window) => normalizeText(window.title) === query);
-	if (exactMatches.length === 1) return exactMatches[0];
-	if (exactMatches.length > 1) {
-		const clearWinner = chooseRankedWindowOrUndefined(exactMatches);
-		if (clearWinner) return clearWinner;
-		throw new Error(
-			`Window title '${windowTitle}' is ambiguous in app '${appName}'. Candidates: ${summarizeWindowCandidates(exactMatches)}.`,
-		);
-	}
-
-	const partialMatches = windows.filter((window) => normalizeText(window.title).includes(query));
-	if (partialMatches.length === 0) {
-		throw new Error(
-			`Window '${windowTitle}' was not found in app '${appName}'. Available windows: ${summarizeWindowCandidates(windows)}.`,
-		);
-	}
-	if (partialMatches.length === 1) return partialMatches[0];
-	const clearWinner = chooseRankedWindowOrUndefined(partialMatches);
-	if (clearWinner) return clearWinner;
-
-	throw new Error(
-		`Window title '${windowTitle}' is ambiguous in app '${appName}'. Candidates: ${summarizeWindowCandidates(partialMatches)}.`,
-	);
 }
 
 function toResolvedTarget(app: HelperApp, window: HelperWindow): ResolvedTarget {
@@ -1028,114 +978,12 @@ async function resolveFrontmostTarget(signal?: AbortSignal): Promise<ResolvedTar
 }
 
 function matchesObserveSelection(target: ResolvedTarget, selection: ObserveTargetParams): boolean {
-	const windowQuery = normalizeWindowSelector(selection.root);
-	if (windowQuery) {
-		if (target.windowRef === windowQuery) return true;
-		const numeric = Number(windowQuery);
-		return Number.isInteger(numeric) && numeric > 0 && target.windowId === numeric;
-	}
-	const appQuery = trimOrUndefined(selection.app);
-	const windowTitleQuery = trimOrUndefined(selection.windowTitle);
-	if (appQuery && !normalizeText(target.appName).includes(normalizeText(appQuery))) {
-		return false;
-	}
-	if (windowTitleQuery && normalizeText(target.windowTitle) !== normalizeText(windowTitleQuery)) {
-		return false;
-	}
-	return true;
+	const root = normalizeWindowSelector(selection.root);
+	return !root || target.windowRef === root;
 }
 
-async function resolveTargetForObserve(selection: ObserveTargetParams, signal?: AbortSignal): Promise<ResolvedTarget> {
-	const appQuery = trimOrUndefined(selection.app);
-	const windowTitleQuery = trimOrUndefined(selection.windowTitle);
-
-	if (!appQuery && !windowTitleQuery) {
-		if (operationState().currentTarget) {
-			return await resolveCurrentTarget(signal);
-		}
-		return await resolveFrontmostTarget(signal);
-	}
-
-	if (appQuery) {
-		const apps = await listApps(signal);
-		const app = chooseAppByQuery(apps, appQuery);
-		assertBrowserUseAllowed(app);
-		let windows = await listWindows(app.pid, signal);
-		if (!windows.length) {
-			throw new Error(`No controllable root was found in app '${app.appName}'.`);
-		}
-
-		let window: HelperWindow;
-		if (windowTitleQuery) {
-			window = chooseWindowByTitle(windows, windowTitleQuery, app.appName);
-		} else if (currentPlatformBackend.isBrowserApp(app.appName, app.bundleId)) {
-			const current = operationState().currentTarget;
-			const currentBrowserWindow =
-				current && current.pid === app.pid ? windows.find((candidate) => candidate.windowId === current.windowId) : undefined;
-			window = currentBrowserWindow ?? choosePreferredWindow(windows, app.appName);
-		} else {
-			window = choosePreferredWindow(windows, app.appName);
-		}
-
-		const resolved = toResolvedTarget(app, window);
-		setCurrentTarget(resolved);
-		return resolved;
-	}
-
-	const query = windowTitleQuery!;
-	const exactMatches: Array<{ app: HelperApp; window: HelperWindow }> = [];
-	const partialMatches: Array<{ app: HelperApp; window: HelperWindow }> = [];
-
-	let titleRoots: HelperWindow[] = [];
-	for (let attempt = 0; attempt < 20 && titleRoots.length === 0; attempt += 1) {
-		titleRoots = await listWindowsByTitle(query, signal);
-		if (titleRoots.length === 0 && attempt < 19) await sleep(100, signal);
-	}
-	for (const window of titleRoots) {
-		if (!window.pid) continue;
-		const app: HelperApp = { appName: window.appName ?? "Unknown App", bundleId: window.bundleId, pid: window.pid };
-		const title = normalizeText(window.title);
-		if (!title) continue;
-		if (title === normalizeText(query)) {
-			exactMatches.push({ app, window });
-		} else if (title.includes(normalizeText(query))) {
-			partialMatches.push({ app, window });
-		}
-	}
-	// Some freshly created or off-Space windows are absent from WindowServer's
-	// title index for a short period. Preserve complete discovery as a cold-path
-	// fallback instead of turning that presentation lag into a false miss.
-	if (exactMatches.length === 0 && partialMatches.length === 0) {
-		for (const app of await listApps(signal)) {
-			for (const window of await listWindows(app.pid, signal)) {
-				const title = normalizeText(window.title);
-				if (title === normalizeText(query)) exactMatches.push({ app, window });
-				else if (title.includes(normalizeText(query))) partialMatches.push({ app, window });
-			}
-		}
-	}
-
-	const matches = exactMatches.length > 0 ? exactMatches : partialMatches;
-	if (matches.length === 0) {
-		throw new Error(`Window '${query}' was not found in any running app.`);
-	}
-	if (matches.length > 1) {
-		const ranked = [...matches].sort((a, b) => scoreWindow(b.window) - scoreWindow(a.window));
-		if (ranked.length > 1 && scoreWindow(ranked[0].window) >= scoreWindow(ranked[1].window) + 25) {
-			const resolved = toResolvedTarget(ranked[0].app, ranked[0].window);
-			setCurrentTarget(resolved);
-			return resolved;
-		}
-		const options = ranked
-			.slice(0, 6)
-			.map((match) => `${match.app.appName} — ${summarizeWindowCandidate(match.window)}`)
-			.join(", ");
-		throw new Error(`Window title '${query}' is ambiguous (${options}). Specify app as well.`);
-	}
-
-	const resolved = toResolvedTarget(matches[0].app, matches[0].window);
-	setCurrentTarget(resolved);
-	return resolved;
+async function resolveTargetForObserve(signal?: AbortSignal): Promise<ResolvedTarget> {
+	return operationState().currentTarget ? await resolveCurrentTarget(signal) : await resolveFrontmostTarget(signal);
 }
 
 async function ensureTargetWindowId(target: ResolvedTarget, signal?: AbortSignal): Promise<ResolvedTarget> {
@@ -1447,9 +1295,9 @@ function rootDeltaLines(execution: ExecutionTrace): string[] {
 
 // Side effect: stores stable @r refs for discovered windows in runtimeState.
 async function collectWindowDetails(apps: HelperApp[], config: ReturnType<typeof getComputerUseConfig>, signal?: AbortSignal): Promise<ListWindowsDetails["windows"]> {
+	const perApp = await Promise.all(apps.map(async (app) => ({ app, windows: await listWindows(app.pid, signal) })));
 	const windows: ListWindowsDetails["windows"] = [];
-	for (const app of apps) {
-		const appWindows = await listWindows(app.pid, signal);
+	for (const { app, windows: appWindows } of perApp) {
 		for (const window of appWindows) {
 			const storedRef = storeWindowRefForAppWindow(app, window);
 			windows.push({
@@ -1485,7 +1333,7 @@ async function collectWindowDetails(apps: HelperApp[], config: ReturnType<typeof
 async function performListWindows(params: FindParams, signal?: AbortSignal): Promise<AgentToolResult<ListWindowsDetails>> {
 	const rawParams = params ?? {};
 	const query: FindParams = {
-		query: trimOrUndefined(rawParams.query),
+		text: trimOrUndefined(rawParams.text),
 		app: trimOrUndefined(rawParams.app),
 		bundleId: trimOrUndefined(rawParams.bundleId),
 		pid: Number.isFinite(rawParams.pid) ? Math.trunc(rawParams.pid!) : undefined,
@@ -1494,7 +1342,8 @@ async function performListWindows(params: FindParams, signal?: AbortSignal): Pro
 	const matchingApps = (await listApps(signal)).filter((app) => appMatchesWindowQuery(app, query));
 	const config = getComputerUseConfig();
 	const desktopForest = await collectWindowDetails(matchingApps, config, signal);
-	const browserForest: ListWindowsDetails["windows"] = query.pid || query.bundleId || query.app || !config.browser_use ? [] : (await listCdpPageContexts().catch(() => []))
+	const includeBrowserPages = !query.pid && !query.bundleId && (!query.app || normalizeText(query.app) === "browser") && config.browser_use;
+	const browserForest: ListWindowsDetails["windows"] = !includeBrowserPages ? [] : (await listCdpPageContexts().catch(() => []))
 		.map((page) => ({
 			app: "Browser",
 			pid: 0,
@@ -1515,18 +1364,18 @@ async function performListWindows(params: FindParams, signal?: AbortSignal): Pro
 		}));
 	const allRoots = [...desktopForest, ...browserForest];
 	const forest = allRoots.filter((root) => !query.kind || root.kind === query.kind);
-	const normalizedQuery = normalizeText(query.query ?? "");
-	const exact = normalizedQuery ? forest.filter((root) => normalizeText(root.app) === normalizedQuery || normalizeText(root.windowTitle) === normalizedQuery) : [];
-	const fuzzy = normalizedQuery && exact.length === 0
-		? forest.filter((root) => `${normalizeText(root.app)} ${normalizeText(root.windowTitle)}`.includes(normalizedQuery))
-		: [];
-	const windows = (exact.length > 0 ? exact : fuzzy.length > 0 ? fuzzy : forest)
-		.sort((a, b) => Number(b.isFocused) - Number(a.isFocused) || a.zOrder - b.zOrder || a.app.localeCompare(b.app));
-	const details: ListWindowsDetails = { tool: "find_roots", query, windows, config };
+	const ranked = forest.map((root, order) => ({ root, order, match: query.text ? rankedTextMatch([root.app, root.windowTitle], query.text) : { reason: "filter" as const, score: 1 } }))
+		.filter((entry) => entry.match)
+		.sort((a, b) => b.match!.score - a.match!.score || Number(b.root.isFocused) - Number(a.root.isFocused) || a.root.zOrder - b.root.zOrder || a.order - b.order);
+	const totalMatches = ranked.length;
+	const windows = ranked.slice(0, 12).map((entry) => entry.root);
+	const details: ListWindowsDetails = { tool: "find_roots", query, windows, totalMatches, returned: windows.length, hasMore: totalMatches > windows.length, config };
 	const lines = windows.map(formatWindowLine);
 	const text = lines.length
-		? `Found ${lines.length} root${lines.length === 1 ? "" : "s"}${query.query ? ` for ${JSON.stringify(query.query)}` : ""}. Use @r refs with observe({ root: "@rN" }).\n${lines.join("\n")}`
-		: `No roots are currently visible to pi-computer-use.`;
+		? `Found ${totalMatches} matching root${totalMatches === 1 ? "" : "s"}; returned ${windows.length}${totalMatches > windows.length ? ". Refine the filters for additional roots" : ""}. Use @r refs with observe_ui({ root: "@rN" }).\n${lines.join("\n")}`
+		: query.text || query.app || query.bundleId || query.pid || query.kind
+			? "No roots matched the supplied filters."
+			: "No roots are currently visible to pi-computer-use.";
 	return { content: [{ type: "text", text }], details };
 }
 
@@ -1587,9 +1436,9 @@ async function refreshBrowserSnapshot(contextId: string, tool: string, base?: { 
 	return browserObservationResult(browser, resourceKey, state.epoch ?? resourceScheduler.epoch(resourceKey), tool, base);
 }
 
-function sliceText(value: string, offsetValue: unknown, limitValue: unknown): Pick<ReadTextDetails, "offset" | "limit" | "totalChars" | "hasMore" | "text"> {
+function sliceText(value: string, offsetValue: unknown, _limitValue?: unknown): Pick<ReadTextDetails, "offset" | "limit" | "totalChars" | "hasMore" | "text"> {
 	const offset = Math.max(0, Math.trunc(toFiniteNumber(offsetValue, 0)));
-	const limit = Math.max(1, Math.min(100_000, Math.trunc(toFiniteNumber(limitValue, 4_000))));
+	const limit = UI_TEXT_PAGE_CHARS;
 	const characters = Array.from(value);
 	const end = Math.min(characters.length, offset + limit);
 	return {
@@ -1602,12 +1451,27 @@ function sliceText(value: string, offsetValue: unknown, limitValue: unknown): Pi
 }
 
 async function performReadText(params: ReadTextParams, signal?: AbortSignal): Promise<AgentToolResult<ReadTextDetails>> {
-	const contextId = operationState().contextId;
 	const ref = trimOrUndefined(params.ref);
+	if (ref?.startsWith("@o")) {
+		const page = readStoredOutput(ref, params.offset);
+		if (!page) throw new Error(`Output ref '${ref}' is unavailable or was evicted. Rerun the focused query.`);
+		const details: ReadTextDetails = { tool: "read_text", ref, ...page };
+		const suffix = page.hasMore
+			? `\n\ncontinue: read_text({ ref: "${ref}", offset: ${page.offset + page.limit} })`
+			: page.complete ? "" : "\n\ncontinuation storage limit reached; rerun a more focused query for the remainder";
+		return { content: [{ type: "text", text: `${page.text || "(empty output page)"}${suffix}` }], details };
+	}
+	const contextId = operationState().contextId;
 	if (isBrowserContextId(contextId)) {
 		const snapshot = operationState().browserSnapshot;
 		if (!snapshot || snapshot.contextId !== contextId) throw new Error(`Browser state '${params.stateId}' is unavailable. Observe the browser root again.`);
-		const sliced = sliceText(snapshot.text, params.offset, params.limit);
+		if (!ref) throw new Error("read_text requires an @e ref for browser contexts; use the outline root ref for whole-page text.");
+		const outline = restoreOutline(snapshot.outline);
+		const node = nodeByRef(outline, ref);
+		if (!node) throw new Error(`Browser text ref '${ref}' is unavailable in this state.`);
+		const collect = (current: OutlineNode): string[] => [outlineNodeLabel(current), ...current.text.map((item) => item.string), ...current.children.flatMap(collect)].filter(Boolean);
+		const value = node === outline.root ? snapshot.text : [...new Set(collect(node))].join("\n");
+		const sliced = sliceText(value, params.offset);
 		const details: ReadTextDetails = { tool: "read_text", ref, ...sliced };
 		return { content: [{ type: "text", text: sliced.text || "(empty text slice)" }], details };
 	}
@@ -1621,7 +1485,7 @@ async function performReadText(params: ReadTextParams, signal?: AbortSignal): Pr
 		lookId: state.currentOutline!.lookId,
 		elementRef: wireRefForNode(node),
 		offset: Math.max(0, Math.trunc(toFiniteNumber(params.offset, 0))),
-		limit: Math.max(1, Math.min(100_000, Math.trunc(toFiniteNumber(params.limit, 4_000)))),
+		limit: UI_TEXT_PAGE_CHARS,
 	}, { signal, timeoutMs: COMMAND_TIMEOUT_MS }))).value;
 	const text = raw.text;
 	const details: ReadTextDetails = {
@@ -1640,12 +1504,53 @@ function normalizeWaitTimeoutMs(value: unknown): number {
 	return Math.max(100, Math.min(60_000, Math.trunc(toFiniteNumber(value, 10_000))));
 }
 
-async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Promise<AgentToolResult<WaitForDetails>> {
-	const contextId = operationState().contextId;
+function conditionScopeRef(params: WaitForParams | NonNullable<ActParams["expect"]>): string | undefined {
+	const ref = trimOrUndefined(params.ref);
+	const scopeRef = trimOrUndefined(params.scopeRef);
+	if (ref && scopeRef) throw new Error("A UI condition accepts ref or scopeRef, not both.");
+	return ref ?? scopeRef;
+}
+
+function validateCondition(params: WaitForParams | NonNullable<ActParams["expect"]>): { text?: string; role?: string; value?: string; scopeRef?: string; scopeExact: boolean; gone: boolean; timeoutMs: number } {
 	const text = trimOrUndefined(params.text);
 	const role = trimOrUndefined(params.role);
-	const timeoutMs = normalizeWaitTimeoutMs(params.timeoutMs);
-	if (!text && !role) throw new Error("wait_for requires text or role.");
+	const value = trimOrUndefined(params.value);
+	const scopeRef = conditionScopeRef(params);
+	if (!text && !role && !value) throw new Error("A UI condition requires text, role, or value.");
+	if (role && !text && !value && !scopeRef) throw new Error("A role-only UI condition requires ref or scopeRef.");
+	if (value && !params.ref) throw new Error("A value UI condition requires an exact ref.");
+	return { text, role, value, scopeRef, scopeExact: Boolean(params.ref), gone: params.until === "absent", timeoutMs: normalizeWaitTimeoutMs(params.timeoutMs) };
+}
+
+function nodeWithinScope(node: OutlineNode, scopeRef: string | undefined, scopeExact: boolean): boolean {
+	if (!scopeRef) return true;
+	if (scopeExact) return node.ref === scopeRef;
+	let current: OutlineNode | undefined = node;
+	while (current) {
+		if (current.ref === scopeRef) return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function normalizedRole(value: string): string {
+	return value.toLowerCase().replace(/^ax/, "").replace(/[ _-]+/g, "");
+}
+
+function platformRole(outline: Outline, role: string | undefined): string | undefined {
+	if (!role) return undefined;
+	return outline.nodes.find((node) => normalizedRole(node.role) === normalizedRole(role))?.role ?? role;
+}
+
+function outlineConditionPresent(outline: Outline, condition: ReturnType<typeof validateCondition>): boolean {
+	return searchOutline(outline, condition.text, undefined, undefined, outline.nodes.length)
+		.some((match) => (!condition.role || normalizedRole(match.node.role) === normalizedRole(condition.role)) && nodeWithinScope(match.node, condition.scopeRef, condition.scopeExact) && (!condition.value || normalizeText(match.node.value) === normalizeText(condition.value)));
+}
+
+async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Promise<AgentToolResult<WaitForDetails>> {
+	const contextId = operationState().contextId;
+	const condition = validateCondition(params);
+	const { text, role, value, scopeRef, scopeExact, gone, timeoutMs } = condition;
 
 	if (isBrowserContextId(contextId)) {
 		const state = operationState();
@@ -1662,8 +1567,8 @@ async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Prom
 			const transition = changesBetween(restoreOutline(baseSnapshot.outline), successorOutline);
 			const useDiff = !transition.useFullView;
 			const renderedOutline = foldToBudget(successorOutline).text;
-			const details: WaitForDetails = { tool: "wait_for", stateId: lastSnapshot.snapshotId, baseStateId: baseSnapshot.snapshotId, view: useDiff ? "diff" : "full", changes: useDiff ? transition.changes : undefined, found, gone: found && params.gone === true || undefined, timedOut, nodeCount: lastSnapshot.targets.length, text, role, outline: lastSnapshot.outline, renderedOutline };
-			const message = found ? (params.gone ? "Condition disappeared." : "Condition appeared.") : `Timed out after ${timeoutMs}ms waiting for condition.`;
+			const details: WaitForDetails = { tool: "wait_for", stateId: lastSnapshot.snapshotId, baseStateId: baseSnapshot.snapshotId, view: useDiff ? "diff" : "full", changes: useDiff ? transition.changes : undefined, found, gone: found && gone || undefined, timedOut, nodeCount: lastSnapshot.targets.length, text, role, value, scopeRef, outline: lastSnapshot.outline, renderedOutline };
+			const message = found ? (gone ? "Condition disappeared." : "Condition appeared.") : `Timed out after ${timeoutMs}ms waiting for condition.`;
 			const viewText = useDiff ? `${renderChanges(transition.changes) || "(no element changes)"}\nUse stateId ${lastSnapshot.snapshotId} for subsequent actions and queries.` : renderedOutline;
 			return { content: [{ type: "text", text: `${message}\n${viewText}` }], details };
 		};
@@ -1672,10 +1577,8 @@ async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Prom
 			lastSnapshot = scheduled.value;
 			lastEpoch = scheduled.epoch;
 			if (!lastSnapshot) throw new Error(`Browser root '${contextId}' is no longer available. Call find_roots and observe_ui again.`);
-			const matchesText = !text || lastSnapshot.text.toLowerCase().includes(text.toLowerCase()) || lastSnapshot.targets.some((target) => target.name.toLowerCase().includes(text.toLowerCase()));
-			const matchesRole = !role || lastSnapshot.targets.some((target) => target.role === role);
-			const found = matchesText && matchesRole;
-			if (found !== (params.gone === true)) return finish(true);
+			const present = outlineConditionPresent(restoreOutline(lastSnapshot.outline), condition);
+			if (present !== gone) return finish(true);
 			await sleep(200, signal);
 		} while (Date.now() < deadline);
 		return finish(false, true);
@@ -1685,11 +1588,17 @@ async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Prom
 	const baseView = { stateId: state.currentCapture!.stateId, outline: state.currentOutline! };
 	let target = await resolveCurrentTarget(signal);
 	target = await ensureTargetWindowId(target, signal);
+	const scopeNode = scopeRef ? nodeByRef(state.currentOutline!, scopeRef) : undefined;
+	if (scopeRef && !scopeNode) throw new Error(`Condition scope ref '${scopeRef}' is unavailable in this state.`);
 	const raw = await currentPlatformBackend.waitFor({
 		...nativeWindowRequest(target),
+		lookId: state.currentOutline!.lookId,
 		text,
-		role,
-		gone: params.gone === true,
+		role: platformRole(state.currentOutline!, role),
+		value,
+		scopeRef: scopeNode ? wireRefForNode(scopeNode) : undefined,
+		scopeExact,
+		gone,
 		timeoutMs,
 	}, { signal, timeoutMs: timeoutMs + 2_000 });
 	if (!state.resourceKey || state.epoch === undefined) throw new Error("The observation has no live resource identity. Observe again.");
@@ -1711,6 +1620,8 @@ async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Prom
 		nodeCount: Number.isFinite(raw.nodeCount) ? Number(raw.nodeCount) : refreshed.outline.nodes.length,
 		text,
 		role,
+		value,
+		scopeRef,
 		outline: serializeOutline(refreshed.outline),
 		renderedOutline: foldToBudget(refreshed.outline).text,
 	};
@@ -1729,6 +1640,7 @@ function sameRootIdentity(a: CurrentTarget, b: CurrentTarget): boolean {
 /** Side effects: captures/updates current target, capture state, look, and parsed outline. */
 async function performObserve(params: ObserveParams, signal?: AbortSignal): Promise<AgentToolResult<ComputerUseDetails | BrowserObservationDetails>> {
 	const requestedRoot = typeof params.root === "string" ? params.root : undefined;
+	if (requestedRoot && !/^@r\d+$/.test(requestedRoot)) throw new Error("observe_ui.root must be an exact @r ref issued by find_roots.");
 	const browserContextId = requestedRoot ? runtimeState.browserContextByRoot.get(requestedRoot) : undefined;
 	if (isBrowserContextId(browserContextId)) {
 		const targetId = browserContextId.slice(BROWSER_CONTEXT_PREFIX.length);
@@ -1740,18 +1652,14 @@ async function performObserve(params: ObserveParams, signal?: AbortSignal): Prom
 	}
 	const state = operationState();
 	const mode = params.mode ?? "fused";
-	const image = params.image ?? (mode === "semantic" ? "never" : mode === "visual" ? "always" : "auto");
+	const image = mode === "semantic" ? "never" : mode === "visual" ? "always" : "auto";
 	const defaultReadText = mode === "semantic" ? "never" : mode === "visual" ? "always" : "auto";
 	const readText = params.readText ?? defaultReadText;
 	state.currentImageMode = normalizeImageMode(image);
-	const selection = {
-		app: trimOrUndefined(params.app),
-		windowTitle: trimOrUndefined(params.windowTitle),
-		root: normalizeWindowSelector(params.root),
-	};
+	const selection: ObserveTargetParams = { root: normalizeWindowSelector(params.root) };
 	const requestedTarget = selection.root
 		? await resolveTargetByWindowSelector(params.root!, signal)
-		: await resolveTargetForObserve(selection, signal);
+		: await resolveTargetForObserve(signal);
 	const imageMode = normalizeImageMode(image);
 	const resourceKey = desktopResourceKey(requestedTarget);
 	const scheduled = await resourceScheduler.read(resourceKey, async (epoch) => {
@@ -1794,9 +1702,11 @@ async function performSearchUi(params: SearchUiParams, signal?: AbortSignal): Pr
 	let outline = currentOutlineOrThrow(params.stateId);
 	const text = trimOrUndefined(params.text);
 	const role = trimOrUndefined(params.role);
-	const action = trimOrUndefined(params.action);
-	const limit = Math.max(1, Math.min(50, Math.trunc(toFiniteNumber(params.limit, 12))));
-	let matches = searchOutline(outline, text, role, action, limit);
+	const capability = trimOrUndefined(params.capability);
+	if (!text && !role && !capability) throw new Error("search_ui requires text, role, or capability. Use observe_ui for a bounded overview.");
+	const limit = 12;
+	let ranked = searchOutlineRanked(outline, text, role, capability, limit);
+	let matches = ranked.matches;
 	let escalatedOCR = false;
 	const look = state.currentLook;
 	if (shouldEscalateSearchOCR(matches, text) && look && look.readText?.requested !== "never" && !look.readText?.executed && state.lastSearchOcrEscalatedLookId !== look.lookId) {
@@ -1809,16 +1719,18 @@ async function performSearchUi(params: SearchUiParams, signal?: AbortSignal): Pr
 		if (!state.resourceKey || state.epoch === undefined) throw new Error("The observation has no live resource identity. Observe again.");
 		const captureResult = (await resourceScheduler.readAt(state.resourceKey, state.epoch, async () => await captureCurrentTarget(signal, "always", AUTO_IMAGE_MAX_DIMENSION, currentTarget))).value;
 		outline = captureResult.outline;
-		matches = searchOutline(outline, text, role, action, limit);
+		ranked = searchOutlineRanked(outline, text, role, capability, limit);
+		matches = ranked.matches;
 		escalatedOCR = true;
 	}
-	const detailMatches = matches.map((match) => ({ ...match, node: serializeOutlineNode(match.node) }));
-	const details: OutlineToolDetails = { tool: "search_ui", stateId: state.currentCapture?.stateId, lookId: outline.lookId, outline: serializeOutline(outline), matches: detailMatches, note: state.currentNote };
-	const lines = matches.map((match) => `${match.ref} ${match.role || "Unknown"} ${JSON.stringify(match.label || "(unlabeled)")}\n  path: ${match.path}`);
+	const detailMatches = matches.map(({ node: _node, ...match }) => match);
+	const details: OutlineToolDetails = { tool: "search_ui", stateId: state.currentCapture?.stateId, lookId: outline.lookId, matches: detailMatches, totalMatches: ranked.totalMatches, returned: matches.length, hasMore: ranked.totalMatches > matches.length, note: state.currentNote };
+	const lines = matches.map((match) => `${match.ref} ${match.role || "Unknown"} ${JSON.stringify(match.label || "(unlabeled)")} [${match.matchReason}${match.matchReason === "fuzzy" ? ` ${match.score?.toFixed(2)}` : ""}]\n  path: ${match.path}`);
 	const noteHeader = renderNote(state.currentNote);
 	const noteText = noteHeader ? `${noteHeader}\n\n` : "";
 	const escalationText = escalatedOCR ? " OCR text was escalated for this search after the cached outline had no matches." : "";
-	return { content: [{ type: "text", text: `${noteText}Found ${matches.length} outline match${matches.length === 1 ? "" : "es"}.${escalationText}\n${lines.join("\n")}` }], details };
+	const moreText = ranked.totalMatches > matches.length ? ` Refine the query to inspect ${ranked.totalMatches - matches.length} additional matches.` : "";
+	return { content: [{ type: "text", text: `${noteText}Found ${ranked.totalMatches} outline match${ranked.totalMatches === 1 ? "" : "es"}; returned ${matches.length}.${moreText}${escalationText}\n${lines.join("\n")}` }], details };
 }
 
 /** Reads cached outline; truncated refs trigger a scoped look. */
@@ -1851,7 +1763,7 @@ async function performExpandUi(params: ExpandUiParams, signal?: AbortSignal): Pr
 		persistOperation(state);
 	}
 	const folded = foldToBudget(outline, { maxDepth: depth, maxNodes: 150 }, [target.ref]);
-	const details: OutlineToolDetails = { tool: "expand_ui", stateId: state.currentCapture?.stateId, lookId: outline.lookId, outline: serializeOutline(outline), target: serializeOutlineNode(target), renderedOutline: folded.text, note: state.currentNote };
+	const details: OutlineToolDetails = { tool: "expand_ui", stateId: state.currentCapture?.stateId, lookId: outline.lookId, target: serializeOutlineNodeShallow(target), renderedOutline: folded.text, note: state.currentNote };
 	return { content: [{ type: "text", text: `${formatOutlineNodeLabel(target)}\npath: ${outlineNodePath(target)}\n\n${folded.text}` }], details };
 }
 
@@ -1863,7 +1775,7 @@ async function performInspectUi(params: InspectUiParams, signal?: AbortSignal): 
 	if (!ref) throw new Error("inspect_ui.ref is required.");
 	const target = nodeByRef(outline, ref);
 	if (!target) throw new Error(`Outline ref '${ref}' is not available in the current outline.`);
-	const details: OutlineToolDetails = { tool: "inspect_ui", stateId: state.currentCapture?.stateId, lookId: outline.lookId, outline: serializeOutline(outline), target: serializeOutlineNode(target), raw: params.includeRaw ? serializeOutlineNode(target) : undefined, note: state.currentNote };
+	const details: OutlineToolDetails = { tool: "inspect_ui", stateId: state.currentCapture?.stateId, lookId: outline.lookId, target: serializeOutlineNodeShallow(target), note: state.currentNote };
 	const fields = [
 		formatOutlineNodeLabel(target),
 		`path: ${outlineNodePath(target)}`,
@@ -1915,7 +1827,7 @@ async function dispatchUiTransaction(actions: UiAction[], target: ResolvedTarget
 	// Strict-headless batches have one immutable delivery class. When foreground
 	// fallback is permitted, decide independently per action so a completed
 	// background prefix is never replayed as part of a foreground batch.
-	if (headless && currentPlatformBackend.actBatch && actions.every((action) => action.action !== "wait")) {
+	if (headless && currentPlatformBackend.actBatch) {
 		const actionState: ActionState = { currentFocus: false };
 		const requests = actions.map((action) => helperActRequest(target, prepareUiAction(action, actionState, look, true) as NativePreparedAction, "ax_only"));
 		const textLength = actions.reduce((sum, action) => sum + (action.text?.length ?? 0), 0);
@@ -1957,30 +1869,32 @@ function aggregateExecutions(steps: ExecutionTrace[]): ExecutionTrace {
 
 async function performDesktopTransaction(params: ActParams, actions: UiAction[], signal?: AbortSignal): Promise<AgentToolResult<ComputerUseDetails>> {
 	const state = operationState();
-	state.currentImageMode = normalizeImageMode(params.image);
+	state.currentImageMode = "auto";
 	validateStateId(params.stateId);
 	const look = currentLookOrThrow();
 	const baseView = { stateId: state.currentCapture!.stateId, outline: state.currentOutline! };
 	const target = await ensureTargetWindowId(await resolveCurrentTarget(signal), signal);
 	const noteBefore = state.currentNote;
 	return await withWindowWriteLock(target, async () => {
-		const headless = params.headless ?? getComputerUseConfig().headless;
+		const headless = getComputerUseConfig().headless;
 		const execution = await dispatchUiTransaction(actions, target, look, headless, signal);
 		const executedActions = actions.slice(0, execution.actionCount ?? actions.length);
-		const expectedText = trimOrUndefined(params.expect?.text);
-		const expectedRole = trimOrUndefined(params.expect?.role);
-		const expectedValue = trimOrUndefined(params.expect?.value);
-		if (params.expect && !expectedText && !expectedRole && !expectedValue) throw new Error("act_ui.expect requires text, role, or value.");
-		if (params.expect) {
-			const timeoutMs = normalizeWaitTimeoutMs(params.expect.timeoutMs);
-			const beforePresent = searchOutline(look.parsedOutline!, expectedText, expectedRole, undefined, 50).some((match) => !expectedValue || normalizeText(match.node.value) === normalizeText(expectedValue));
-			const desiredWasPreexisting = beforePresent !== (params.expect.gone === true);
+		const condition = params.expect ? validateCondition(params.expect) : undefined;
+		if (condition) {
+			const { text: expectedText, role: expectedRole, value: expectedValue, scopeRef, scopeExact, gone, timeoutMs } = condition;
+			const beforePresent = outlineConditionPresent(look.parsedOutline!, condition);
+			const desiredWasPreexisting = beforePresent !== gone;
+			const scopeNode = scopeRef ? nodeByRef(look.parsedOutline!, scopeRef) : undefined;
+			if (scopeRef && !scopeNode) throw new Error(`Condition scope ref '${scopeRef}' is unavailable in this state.`);
 			const verification = await currentPlatformBackend.waitFor({
 				...nativeWindowRequest(target),
+				lookId: look.parsedOutline!.lookId,
 				text: expectedText,
-				role: expectedRole,
+				role: platformRole(look.parsedOutline!, expectedRole),
 				value: expectedValue,
-				gone: params.expect.gone === true,
+				scopeRef: scopeNode ? wireRefForNode(scopeNode) : undefined,
+				scopeExact,
+				gone,
 				timeoutMs,
 			}, { signal, timeoutMs: timeoutMs + 2_000 });
 			execution.verification = {
@@ -1988,7 +1902,7 @@ async function performDesktopTransaction(params: ActParams, actions: UiAction[],
 				text: expectedText,
 				role: expectedRole,
 				value: expectedValue,
-				gone: params.expect.gone === true || undefined,
+				gone: gone || undefined,
 				timeoutMs,
 			};
 			execution.outcome = outcomeAfterCheck(execution.outcome ?? "unknown", execution.verification.status);
@@ -2017,10 +1931,9 @@ async function performBrowserTransaction(params: ActParams, actions: UiAction[],
 	if (!baseSnapshot) throw new Error("Browser transaction requires a complete base observation.");
 	const baseView = { stateId: baseSnapshot.snapshotId, outline: baseSnapshot.outline };
 	const prepared = actions.map((action) => {
-		if (action.action === "wait") return { action };
 		if (!BROWSER_TRANSACTION_ACTIONS.has(action.action)) throw new Error(`Browser transactions do not support '${action.action}'.`);
 		const target = browserSnapshotTarget(params.stateId, trimOrUndefined(action.ref));
-		if ((action.action === "press" || action.action === "click" || action.action === "setText") && !Number.isFinite(target?.backendNodeId)) {
+		if ((action.action === "press" || action.action === "setText" || (action.action === "click" && action.ref) || (action.action === "typeText" && action.ref)) && !Number.isFinite(target?.backendNodeId)) {
 			throw new Error(`Browser ${action.action} requires an actionable @e ref owned by ${params.stateId}.`);
 		}
 		if (action.ref && (!target || target.contextId !== contextId)) throw new Error(`Browser ${action.action} ref must be owned by ${params.stateId}.`);
@@ -2028,41 +1941,63 @@ async function performBrowserTransaction(params: ActParams, actions: UiAction[],
 	});
 	return await withBrowserWrite(contextId, async () => {
 		for (const { action, target } of prepared) {
-			if (action.action === "wait") {
-				await sleep(Math.max(0, Math.min(60_000, Math.round(toFiniteNumber(action.ms, DEFAULT_WAIT_MS)))), signal);
-			} else {
-				let worked = false;
-				if (action.action === "press" || action.action === "click") worked = await cdpClickForContext(contextId, target!.backendNodeId!);
-				else if (action.action === "setText") worked = await cdpTypeForContext(contextId, target!.backendNodeId!, action.text ?? "", true);
-				else if (action.action === "scroll") worked = await cdpScrollForContext(contextId, toFiniteNumber(action.scrollX, 0), toFiniteNumber(action.scrollY, 0), target?.backendNodeId);
-				if (!worked) throw new Error("The browser root became unavailable during the action transaction. Observe it again.");
-			}
+			let worked = false;
+			if (action.action === "press" || (action.action === "click" && action.ref)) {
+				worked = true;
+				for (let count = 0; count < (action.clickCount ?? 1); count += 1) worked = await cdpClickForContext(contextId, target!.backendNodeId!) && worked;
+			} else if (action.action === "click") {
+				worked = await cdpMouseForContext(contextId, action.x!, action.y!, "mousePressed", action.clickCount ?? 1)
+					&& await cdpMouseForContext(contextId, action.x!, action.y!, "mouseReleased", action.clickCount ?? 1);
+			} else if (action.action === "setText") worked = await cdpTypeForContext(contextId, target!.backendNodeId!, action.text ?? "", true);
+			else if (action.action === "typeText") worked = target?.backendNodeId
+				? await cdpTypeForContext(contextId, target.backendNodeId, action.text ?? "", false)
+				: await cdpTypeFocusedForContext(contextId, action.text ?? "");
+			else if (action.action === "keypress") worked = await cdpKeypressForContext(contextId, action.keys ?? []);
+			else if (action.action === "scroll") worked = await cdpScrollForContext(contextId, toFiniteNumber(action.scrollX, 0), toFiniteNumber(action.scrollY, 0), target?.backendNodeId);
+			else if (action.action === "drag") worked = await cdpDragForContext(contextId, normalizeActionPath(action.path));
+			else if (action.action === "moveMouse") worked = await cdpMouseForContext(contextId, action.x!, action.y!, "mouseMoved");
+			if (!worked) throw new Error("The browser root became unavailable during the action transaction. Observe it again.");
 		}
-		const expectedText = trimOrUndefined(params.expect?.text);
-		const expectedRole = trimOrUndefined(params.expect?.role);
-		const expectedValue = trimOrUndefined(params.expect?.value);
-		if (params.expect && !expectedText && !expectedRole && !expectedValue) throw new Error("act_ui.expect requires text, role, or value.");
-		if (params.expect) {
-			const timeoutMs = normalizeWaitTimeoutMs(params.expect.timeoutMs);
-			const deadline = Date.now() + timeoutMs;
+		const condition = params.expect ? validateCondition(params.expect) : undefined;
+		if (condition) {
+			const deadline = Date.now() + condition.timeoutMs;
 			let satisfied = false;
 			do {
 				const snapshot = await cdpSnapshotForContext(contextId);
 				if (!snapshot) throw new Error(`Browser root '${contextId}' is no longer available. Observe it again.`);
-				const present = searchOutline(restoreOutline(snapshot.outline), expectedText, expectedRole, undefined, 50).some((match) => !expectedValue || normalizeText(match.node.value) === normalizeText(expectedValue));
-				satisfied = present !== (params.expect.gone === true);
+				const present = outlineConditionPresent(restoreOutline(snapshot.outline), condition);
+				satisfied = present !== condition.gone;
 				if (!satisfied) await sleep(100, signal);
 			} while (!satisfied && Date.now() < deadline);
-			if (!satisfied) throw new Error(`The browser action was delivered but its postcondition was not satisfied within ${timeoutMs}ms.`);
+			if (!satisfied) throw new Error(`The browser action was delivered but its postcondition was not satisfied within ${condition.timeoutMs}ms.`);
 		}
 		return await refreshBrowserSnapshot(contextId, "act_ui", baseView);
 	});
+}
+
+function normalizeActionPath(path: UiAction["path"]): Array<{ x: number; y: number }> {
+	return (path ?? []).map((point) => Array.isArray(point) ? { x: toFiniteNumber(point[0], 0), y: toFiniteNumber(point[1], 0) } : { x: toFiniteNumber(point.x, 0), y: toFiniteNumber(point.y, 0) });
+}
+
+function validateActionTarget(action: UiAction): void {
+	const hasRef = Boolean(trimOrUndefined(action.ref));
+	const hasX = Number.isFinite(action.x);
+	const hasY = Number.isFinite(action.y);
+	if (hasX !== hasY) throw new Error(`${action.action} coordinates require both x and y.`);
+	const hasPoint = hasX && hasY;
+	if ((action.action === "click" || action.action === "moveMouse") && hasRef === hasPoint) {
+		throw new Error(`${action.action} requires exactly one target: ref or x/y coordinates.`);
+	}
+	if (action.action === "press" && !hasRef) throw new Error("press requires an actionable ref.");
+	if (action.action === "scroll" && toFiniteNumber(action.scrollX, 0) === 0 && toFiniteNumber(action.scrollY, 0) === 0) throw new Error("scroll requires a non-zero scrollX or scrollY delta.");
+	if (action.clickCount !== undefined && (!Number.isInteger(action.clickCount) || action.clickCount < 1 || action.clickCount > 3)) throw new Error("clickCount must be an integer from 1 to 3.");
 }
 
 async function performAct(params: ActParams, signal?: AbortSignal): Promise<AgentToolResult<ComputerUseDetails | BrowserObservationDetails>> {
 	const actions = Array.isArray(params.actions) ? params.actions : [];
 	if (actions.length === 0) throw new Error("act_ui.actions must contain at least one action.");
 	if (actions.length > 20) throw new Error("act_ui supports at most 20 actions per transaction.");
+	for (const action of actions) validateActionTarget(action);
 	if (operationState().contextId) return await performBrowserTransaction(params, actions, signal);
 	return await performDesktopTransaction(params, actions, signal);
 }
@@ -2100,14 +2035,16 @@ async function waitForCdpPort(port: number, signal?: AbortSignal): Promise<void>
 
 // Side effects: starts a Pi-managed browser process, replaces any previous managed browser,
 // and sets PI_COMPUTER_USE_CDP_PORT for subsequent CDP context discovery.
-async function performLaunchBrowser(params: LaunchBrowserParams, signal?: AbortSignal): Promise<AgentToolResult<LaunchBrowserDetails>> {
-	const browser = params.browser === "chrome" ? "chrome" : "helium";
+async function performLaunchBrowser(params: LaunchBrowserParams, signal?: AbortSignal): Promise<AgentToolResult<BrowserObservationDetails>> {
+	const browser = getComputerUseConfig().managed_browser;
 	const executable = managedBrowserExecutable(browser);
 	await access(executable, fsConstants.X_OK).catch(() => {
 		throw new Error(`${browser} executable was not found at ${executable}.`);
 	});
-	const port = Number.isInteger(params.port) && params.port! > 0 ? Math.trunc(params.port!) : await freeTcpPort();
-	const url = trimOrUndefined(params.url) ?? "about:blank";
+	const port = await freeTcpPort();
+	const requestedUrl = trimOrUndefined(params.url);
+	if (requestedUrl && !/^https?:\/\//i.test(requestedUrl)) throw new Error("launch_browser.url must be an absolute HTTP(S) URL.");
+	const url = requestedUrl ?? "about:blank";
 	const profileDir = path.join(os.tmpdir(), `pi-${browser}-cdp-${port}`);
 	disconnectCdp();
 	runtimeState.managedBrowser?.kill("SIGTERM");
@@ -2139,83 +2076,25 @@ async function performLaunchBrowser(params: LaunchBrowserParams, signal?: AbortS
 		}
 		throw error;
 	}
-	const roots = (await listCdpPageContexts()).map((page) => ({ ref: storeBrowserRootRef(page.contextId), kind: "browser_page" as const, title: page.title, url: page.url }));
-	const details: LaunchBrowserDetails = { tool: "launch_browser", browser, port, url, roots };
-	const lines = roots.map((root) => `- ${root.ref} browser_page ${root.title}${root.url ? ` — ${root.url}` : ""}`);
-	return { content: [{ type: "text", text: `Launched ${browser} with CDP on port ${port}. Observe a returned @r root.\n${lines.join("\n")}` }], details };
+	const page = (await listCdpPageContexts())[0];
+	if (!page) throw new Error("Managed browser launched without a CDP page context.");
+	const resourceKey = `cdp:${page.targetId}`;
+	const scheduled = await resourceScheduler.read(resourceKey, async () => await cdpSnapshotForContext(page.contextId));
+	if (!scheduled.value) throw new Error("Managed browser page could not be observed after launch.");
+	return browserObservationResult(scheduled.value, resourceKey, scheduled.epoch, "launch_browser");
 }
 
-async function performNavigateBrowser(params: NavigateBrowserParams, signal?: AbortSignal): Promise<AgentToolResult<ComputerUseDetails | BrowserObservationDetails>> {
+async function performNavigateBrowser(params: NavigateBrowserParams): Promise<AgentToolResult<BrowserObservationDetails>> {
 	const contextId = browserContextForOperation();
 	const url = trimOrUndefined(params.url);
-	if (!url) throw new Error("navigate_browser.url must be a non-empty URL or browser-search string.");
-	if (isBrowserContextId(contextId)) {
-		if (!/^https?:/i.test(url)) throw new Error("navigate_browser on a browser-page state only supports http(s) URLs.");
-		const baseSnapshot = operationState().browserSnapshot;
-		if (!baseSnapshot) throw new Error("Browser navigation requires a complete base observation.");
-		return await withBrowserWrite(contextId, async () => {
-			const ok = await cdpNavigateContext(contextId, url);
-			if (!ok) throw new Error(`Browser context '${contextId}' is no longer available. Observe it again.`);
-			return await refreshBrowserSnapshot(contextId, "navigate_browser", { stateId: baseSnapshot.snapshotId, outline: baseSnapshot.outline });
-		});
-	}
-	operationState().currentImageMode = normalizeImageMode(params.image);
-	const state = operationState();
-	const baseView = { stateId: state.currentCapture!.stateId, outline: state.currentOutline! };
-	const target = await ensureTargetWindowId(await resolveCurrentTarget(signal), signal);
-	assertBrowserUseAllowed(target);
-	if (!currentPlatformBackend.isBrowserApp(target.appName, target.bundleId)) {
-		throw new Error(`navigate_browser requires a browser window, but the target is '${target.appName}'.`);
-	}
-	const scheme = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(url)?.[1];
-	const looksLikeUrl = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//.test(url) || !/\s/.test(url);
-	// Script/local schemes are blocked even when whitespace makes the input
-	// look like a search string: "javascript:var x = 1; alert(x)" is a valid,
-	// dangerous URL despite containing spaces.
-	const dangerousScheme = scheme !== undefined && /^(javascript|data|file|vbscript)$/i.test(scheme);
-	if (scheme && (looksLikeUrl || dangerousScheme) && !/^https?$/i.test(scheme)) {
-		throw new Error(`navigate_browser only supports http(s) URLs or browser-search strings; '${scheme}:' URLs are not allowed.`);
-	}
-	// Prefer CDP when available: event-driven page-load wait and no focus
-	// change. Bare search strings keep the platform browser-open path, which
-	// has address-bar semantics.
-	const cdpTab = /^https?:/i.test(url) && currentPlatformBackend.isChromeFamilyApp(target.appName, target.bundleId)
-		? await cdpTabForWindow(target.windowTitle, target.framePoints)
-		: undefined;
-	if (cdpTab) {
-		return await withWindowWriteLock(target, async () => {
-			await cdpTab.navigate(url);
-			const captureResult = await captureCurrentTarget(signal);
-			return await buildToolResult(
-				"navigate_browser",
-				`Navigated ${captureResult.target.windowRef ? `${captureResult.target.windowRef} ` : ""}${captureResult.target.appName} — ${captureResult.target.windowTitle}. Returned the latest outline state.`,
-				captureResult,
-				executionTrace("cdp_navigate", "stealth"),
-				signal,
-				state.currentImageMode,
-				baseView,
-			);
-		});
-	}
-
-	if (!currentPlatformBackend.isBrowserApp(target.appName, target.bundleId)) {
-		throw new Error(`navigate_browser does not yet support direct URL navigation for '${target.appName}'. Use keypress Command+L, type_text, Enter instead.`);
-	}
-	return await withWindowWriteLock(target, async () => {
-		await focusControlledWindow(target, signal);
-		const opened = await currentPlatformBackend.openBrowserLocation(target, url, signal);
-		if (!opened) throw new Error(`navigate_browser does not yet support direct URL navigation for '${target.appName}'. Use keypress Command+L, type_text, Enter instead.`);
-		await sleep(ACTION_SETTLE_MS, signal);
-		const captureResult = await captureCurrentTarget(signal);
-		return await buildToolResult(
-			"navigate_browser",
-			`Navigated ${captureResult.target.windowRef ? `${captureResult.target.windowRef} ` : ""}${captureResult.target.appName} — ${captureResult.target.windowTitle}. Returned the latest outline state.`,
-			captureResult,
-			executionTrace("browser_open_location", "stealth"),
-			signal,
-			state.currentImageMode,
-			baseView,
-		);
+	if (!contextId) throw new Error("navigate_browser.stateId must belong to a CDP browser-page observation. Native browser windows use act_ui.");
+	if (!url || !/^https?:\/\//i.test(url)) throw new Error("navigate_browser.url must be an absolute HTTP(S) URL.");
+	const baseSnapshot = operationState().browserSnapshot;
+	if (!baseSnapshot) throw new Error("Browser navigation requires a complete base observation.");
+	return await withBrowserWrite(contextId, async () => {
+		const ok = await cdpNavigateContext(contextId, url);
+		if (!ok) throw new Error(`Browser context '${contextId}' is no longer available. Observe it again.`);
+		return await refreshBrowserSnapshot(contextId, "navigate_browser", { stateId: baseSnapshot.snapshotId, outline: baseSnapshot.outline });
 	});
 }
 
@@ -2238,14 +2117,14 @@ async function performEvaluateBrowser(params: EvaluateBrowserParams): Promise<Ag
 			changes: successor.details.changes,
 			outline: successor.details.outline,
 			renderedOutline: successor.details.renderedOutline,
-			value: result.value,
 		};
-		return { content: [{ type: "text", text: `Evaluated JavaScript in the browser root: ${JSON.stringify(result.value)}` }, ...successor.content], details };
+		return { content: [...successor.content, { type: "text", text: `Evaluation value: ${JSON.stringify(result.value)}` }], details };
 	});
 }
 
 async function executeTool<P, T>(ctx: ExtensionContext, params: P, signal: AbortSignal | undefined, run: () => Promise<T>): Promise<T> {
-	const requestedStateId = trimOrUndefined((params as { stateId?: string } | undefined)?.stateId);
+	const outputRef = trimOrUndefined((params as { ref?: string } | undefined)?.ref)?.startsWith("@o") === true;
+	const requestedStateId = outputRef ? undefined : trimOrUndefined((params as { stateId?: string } | undefined)?.stateId);
 	const stateRecord = requestedStateId ? savedStates.get(requestedStateId) : undefined;
 	if (requestedStateId && !stateRecord) {
 		throw new Error(`State '${requestedStateId}' is unavailable or was evicted. Observe the root again.`);
@@ -2260,30 +2139,37 @@ async function executeTool<P, T>(ctx: ExtensionContext, params: P, signal: Abort
 	});
 }
 
-function makeToolExecutor<P, D>(perform: (params: P, signal?: AbortSignal) => Promise<AgentToolResult<D>>) {
+function makeToolExecutor<P, D>(tool: string, perform: (params: P, signal?: AbortSignal) => Promise<AgentToolResult<D>>) {
 	return async (
 		_toolCallId: string,
 		params: P,
 		signal: AbortSignal | undefined,
 		_onUpdate: AgentToolUpdateCallback<D> | undefined,
 		ctx: ExtensionContext,
-	): Promise<AgentToolResult<D>> => await executeTool(ctx, params, signal, () => perform(params, signal));
+	): Promise<AgentToolResult<D>> => {
+		try {
+			return applyOutputEnvelope(tool, await executeTool(ctx, params, signal, () => perform(params, signal)));
+		} catch (error) {
+			throw boundToolError(tool, error);
+		}
+	};
 }
 
-export const executeFind = makeToolExecutor(performListWindows);
-export const executeReadText = makeToolExecutor(performReadText);
-export const executeWaitFor = makeToolExecutor(performWaitFor);
-export const executeObserve = makeToolExecutor(performObserve);
-export const executeSearchUi = makeToolExecutor(performSearchUi);
-export const executeExpandUi = makeToolExecutor(performExpandUi);
-export const executeInspectUi = makeToolExecutor(performInspectUi);
-export const executeAct = makeToolExecutor<ActParams, ComputerUseDetails | BrowserObservationDetails>(performAct);
-export const executeNavigateBrowser = makeToolExecutor(performNavigateBrowser);
-export const executeEvaluateBrowser = makeToolExecutor(performEvaluateBrowser);
-export const executeLaunchBrowser = makeToolExecutor(performLaunchBrowser);
+export const executeFind = makeToolExecutor("find_roots", performListWindows);
+export const executeReadText = makeToolExecutor("read_text", performReadText);
+export const executeWaitFor = makeToolExecutor("wait_for", performWaitFor);
+export const executeObserve = makeToolExecutor("observe_ui", performObserve);
+export const executeSearchUi = makeToolExecutor("search_ui", performSearchUi);
+export const executeExpandUi = makeToolExecutor("expand_ui", performExpandUi);
+export const executeInspectUi = makeToolExecutor("inspect_ui", performInspectUi);
+export const executeAct = makeToolExecutor<ActParams, ComputerUseDetails | BrowserObservationDetails>("act_ui", performAct);
+export const executeNavigateBrowser = makeToolExecutor("navigate_browser", performNavigateBrowser);
+export const executeEvaluateBrowser = makeToolExecutor("evaluate_browser", performEvaluateBrowser);
+export const executeLaunchBrowser = makeToolExecutor("launch_browser", performLaunchBrowser);
 
 export function reconstructStateFromBranch(ctx: ExtensionContext): void {
 	savedStates.clear();
+	clearStoredOutputs();
 	runtimeState.windowRefs.clear();
 	runtimeState.windowRefByIdentity.clear();
 	runtimeState.nextRootRefIndex = 1;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1547,6 +1547,12 @@ function outlineConditionPresent(outline: Outline, condition: ReturnType<typeof 
 		.some((match) => (!condition.role || normalizedRole(match.node.role) === normalizedRole(condition.role)) && nodeWithinScope(match.node, condition.scopeRef, condition.scopeExact) && (!condition.value || normalizeText(match.node.value) === normalizeText(condition.value)));
 }
 
+function conditionScopeNode(outline: Outline, condition: ReturnType<typeof validateCondition>): OutlineNode | undefined {
+	const scopeNode = condition.scopeRef ? nodeByRef(outline, condition.scopeRef) : undefined;
+	if (condition.scopeRef && !scopeNode) throw new Error(`Condition scope ref '${condition.scopeRef}' is unavailable in this state.`);
+	return scopeNode;
+}
+
 async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Promise<AgentToolResult<WaitForDetails>> {
 	const contextId = operationState().contextId;
 	const condition = validateCondition(params);
@@ -1557,6 +1563,7 @@ async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Prom
 		if (!state.resourceKey) throw new Error("The browser observation has no live resource identity. Observe again.");
 		const baseSnapshot = state.browserSnapshot;
 		if (!baseSnapshot) throw new Error("Browser wait requires a complete base observation.");
+		conditionScopeNode(restoreOutline(baseSnapshot.outline), condition);
 		const deadline = Date.now() + timeoutMs;
 		let lastSnapshot: CdpPageSnapshot | undefined;
 		let lastEpoch = state.epoch ?? resourceScheduler.epoch(state.resourceKey);
@@ -1588,8 +1595,7 @@ async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Prom
 	const baseView = { stateId: state.currentCapture!.stateId, outline: state.currentOutline! };
 	let target = await resolveCurrentTarget(signal);
 	target = await ensureTargetWindowId(target, signal);
-	const scopeNode = scopeRef ? nodeByRef(state.currentOutline!, scopeRef) : undefined;
-	if (scopeRef && !scopeNode) throw new Error(`Condition scope ref '${scopeRef}' is unavailable in this state.`);
+	const scopeNode = conditionScopeNode(state.currentOutline!, condition);
 	const raw = await currentPlatformBackend.waitFor({
 		...nativeWindowRequest(target),
 		lookId: state.currentOutline!.lookId,
@@ -1873,19 +1879,18 @@ async function performDesktopTransaction(params: ActParams, actions: UiAction[],
 	validateStateId(params.stateId);
 	const look = currentLookOrThrow();
 	const baseView = { stateId: state.currentCapture!.stateId, outline: state.currentOutline! };
+	const condition = params.expect ? validateCondition(params.expect) : undefined;
+	const scopeNode = condition ? conditionScopeNode(look.parsedOutline!, condition) : undefined;
 	const target = await ensureTargetWindowId(await resolveCurrentTarget(signal), signal);
 	const noteBefore = state.currentNote;
 	return await withWindowWriteLock(target, async () => {
 		const headless = getComputerUseConfig().headless;
 		const execution = await dispatchUiTransaction(actions, target, look, headless, signal);
 		const executedActions = actions.slice(0, execution.actionCount ?? actions.length);
-		const condition = params.expect ? validateCondition(params.expect) : undefined;
 		if (condition) {
 			const { text: expectedText, role: expectedRole, value: expectedValue, scopeRef, scopeExact, gone, timeoutMs } = condition;
 			const beforePresent = outlineConditionPresent(look.parsedOutline!, condition);
 			const desiredWasPreexisting = beforePresent !== gone;
-			const scopeNode = scopeRef ? nodeByRef(look.parsedOutline!, scopeRef) : undefined;
-			if (scopeRef && !scopeNode) throw new Error(`Condition scope ref '${scopeRef}' is unavailable in this state.`);
 			const verification = await currentPlatformBackend.waitFor({
 				...nativeWindowRequest(target),
 				lookId: look.parsedOutline!.lookId,
@@ -1930,8 +1935,11 @@ async function performBrowserTransaction(params: ActParams, actions: UiAction[],
 	const baseSnapshot = operationState().browserSnapshot;
 	if (!baseSnapshot) throw new Error("Browser transaction requires a complete base observation.");
 	const baseView = { stateId: baseSnapshot.snapshotId, outline: baseSnapshot.outline };
+	const condition = params.expect ? validateCondition(params.expect) : undefined;
+	if (condition) conditionScopeNode(restoreOutline(baseSnapshot.outline), condition);
 	const prepared = actions.map((action) => {
 		if (!BROWSER_TRANSACTION_ACTIONS.has(action.action)) throw new Error(`Browser transactions do not support '${action.action}'.`);
+		if (action.action === "click" && action.ref && action.button && action.button !== "left") throw new Error("Browser ref clicks support only the left button; use coordinate clicks for right or middle buttons.");
 		const target = browserSnapshotTarget(params.stateId, trimOrUndefined(action.ref));
 		if ((action.action === "press" || action.action === "setText" || (action.action === "click" && action.ref) || (action.action === "typeText" && action.ref)) && !Number.isFinite(target?.backendNodeId)) {
 			throw new Error(`Browser ${action.action} requires an actionable @e ref owned by ${params.stateId}.`);
@@ -1946,8 +1954,8 @@ async function performBrowserTransaction(params: ActParams, actions: UiAction[],
 				worked = true;
 				for (let count = 0; count < (action.clickCount ?? 1); count += 1) worked = await cdpClickForContext(contextId, target!.backendNodeId!) && worked;
 			} else if (action.action === "click") {
-				worked = await cdpMouseForContext(contextId, action.x!, action.y!, "mousePressed", action.clickCount ?? 1)
-					&& await cdpMouseForContext(contextId, action.x!, action.y!, "mouseReleased", action.clickCount ?? 1);
+				worked = await cdpMouseForContext(contextId, action.x!, action.y!, "mousePressed", action.button ?? "left", action.clickCount ?? 1)
+					&& await cdpMouseForContext(contextId, action.x!, action.y!, "mouseReleased", action.button ?? "left", action.clickCount ?? 1);
 			} else if (action.action === "setText") worked = await cdpTypeForContext(contextId, target!.backendNodeId!, action.text ?? "", true);
 			else if (action.action === "typeText") worked = target?.backendNodeId
 				? await cdpTypeForContext(contextId, target.backendNodeId, action.text ?? "", false)
@@ -1958,7 +1966,6 @@ async function performBrowserTransaction(params: ActParams, actions: UiAction[],
 			else if (action.action === "moveMouse") worked = await cdpMouseForContext(contextId, action.x!, action.y!, "mouseMoved");
 			if (!worked) throw new Error("The browser root became unavailable during the action transaction. Observe it again.");
 		}
-		const condition = params.expect ? validateCondition(params.expect) : undefined;
 		if (condition) {
 			const deadline = Date.now() + condition.timeoutMs;
 			let satisfied = false;

--- a/src/cdp.ts
+++ b/src/cdp.ts
@@ -127,7 +127,7 @@ export class CdpTab {
 
 	/** Evaluates a JS expression in the page and returns its primitive value. */
 	async evaluate(expression: string): Promise<unknown> {
-		const result = await this.send("Runtime.evaluate", { expression, returnByValue: true });
+		const result = await this.send("Runtime.evaluate", { expression, returnByValue: true, timeout: COMMAND_TIMEOUT_MS, awaitPromise: true });
 		return result?.result?.value;
 	}
 
@@ -163,6 +163,31 @@ export class CdpTab {
 			return;
 		}
 		await this.send("Runtime.evaluate", { expression: `window.scrollBy(${JSON.stringify(deltaX)}, ${JSON.stringify(deltaY)})` });
+	}
+
+	async typeIntoFocused(text: string): Promise<void> {
+		await this.send("Input.insertText", { text });
+	}
+
+	async keypress(keys: string[]): Promise<void> {
+		const modifierBits: Record<string, number> = { alt: 1, option: 1, control: 2, ctrl: 2, meta: 4, command: 4, cmd: 4, shift: 8 };
+		const modifiers = keys.reduce((bits, key) => bits | (modifierBits[key.toLowerCase()] ?? 0), 0);
+		for (const key of keys.filter((candidate) => modifierBits[candidate.toLowerCase()] === undefined)) {
+			await this.send("Input.dispatchKeyEvent", { type: "keyDown", key, code: key, text: key.length === 1 && modifiers === 0 ? key : undefined, modifiers });
+			await this.send("Input.dispatchKeyEvent", { type: "keyUp", key, code: key, modifiers });
+		}
+	}
+
+	async mouseAt(x: number, y: number, type: "mouseMoved" | "mousePressed" | "mouseReleased", clickCount = 1): Promise<void> {
+		await this.send("Input.dispatchMouseEvent", { type, x, y, button: type === "mouseMoved" ? "none" : "left", clickCount });
+	}
+
+	async dragPath(path: Array<{ x: number; y: number }>): Promise<void> {
+		if (path.length < 2) throw new Error("CDP drag requires at least two points.");
+		await this.mouseAt(path[0].x, path[0].y, "mousePressed");
+		for (const point of path.slice(1)) await this.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y, button: "left", buttons: 1 });
+		const end = path[path.length - 1];
+		await this.mouseAt(end.x, end.y, "mouseReleased");
 	}
 
 	private async withBackendNode(backendNodeId: number, functionDeclaration: string, args: unknown[] = []): Promise<void> {
@@ -376,6 +401,22 @@ export async function cdpScrollForContext(contextId: string, deltaX: number, del
 		await tab.scrollBy(deltaX, deltaY, backendNodeId);
 		return true;
 	})) === true;
+}
+
+export async function cdpTypeFocusedForContext(contextId: string, text: string): Promise<boolean> {
+	return (await withCdpContextTab(contextId, async (tab) => { await tab.typeIntoFocused(text); return true; })) === true;
+}
+
+export async function cdpKeypressForContext(contextId: string, keys: string[]): Promise<boolean> {
+	return (await withCdpContextTab(contextId, async (tab) => { await tab.keypress(keys); return true; })) === true;
+}
+
+export async function cdpMouseForContext(contextId: string, x: number, y: number, type: "mouseMoved" | "mousePressed" | "mouseReleased", clickCount = 1): Promise<boolean> {
+	return (await withCdpContextTab(contextId, async (tab) => { await tab.mouseAt(x, y, type, clickCount); return true; })) === true;
+}
+
+export async function cdpDragForContext(contextId: string, path: Array<{ x: number; y: number }>): Promise<boolean> {
+	return (await withCdpContextTab(contextId, async (tab) => { await tab.dragPath(path); return true; })) === true;
 }
 
 export async function cdpNavigateContext(contextId: string, url: string): Promise<boolean> {

--- a/src/cdp.ts
+++ b/src/cdp.ts
@@ -178,8 +178,8 @@ export class CdpTab {
 		}
 	}
 
-	async mouseAt(x: number, y: number, type: "mouseMoved" | "mousePressed" | "mouseReleased", clickCount = 1): Promise<void> {
-		await this.send("Input.dispatchMouseEvent", { type, x, y, button: type === "mouseMoved" ? "none" : "left", clickCount });
+	async mouseAt(x: number, y: number, type: "mouseMoved" | "mousePressed" | "mouseReleased", button: "left" | "right" | "middle" = "left", clickCount = 1): Promise<void> {
+		await this.send("Input.dispatchMouseEvent", { type, x, y, button: type === "mouseMoved" ? "none" : button, clickCount });
 	}
 
 	async dragPath(path: Array<{ x: number; y: number }>): Promise<void> {
@@ -411,8 +411,8 @@ export async function cdpKeypressForContext(contextId: string, keys: string[]): 
 	return (await withCdpContextTab(contextId, async (tab) => { await tab.keypress(keys); return true; })) === true;
 }
 
-export async function cdpMouseForContext(contextId: string, x: number, y: number, type: "mouseMoved" | "mousePressed" | "mouseReleased", clickCount = 1): Promise<boolean> {
-	return (await withCdpContextTab(contextId, async (tab) => { await tab.mouseAt(x, y, type, clickCount); return true; })) === true;
+export async function cdpMouseForContext(contextId: string, x: number, y: number, type: "mouseMoved" | "mousePressed" | "mouseReleased", button: "left" | "right" | "middle" = "left", clickCount = 1): Promise<boolean> {
+	return (await withCdpContextTab(contextId, async (tab) => { await tab.mouseAt(x, y, type, button, clickCount); return true; })) === true;
 }
 
 export async function cdpDragForContext(contextId: string, path: Array<{ x: number; y: number }>): Promise<boolean> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ const DEFAULT_CONFIG: ComputerUseConfig = {
 	browser_use: true,
 	headless: false,
 	cursor_overlay: true,
-	managed_browser: "helium",
+	managed_browser: "chrome",
 };
 
 let activeConfig: ComputerUseConfig = { ...DEFAULT_CONFIG };

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export interface ComputerUseConfig {
 	browser_use: boolean;
 	headless: boolean;
 	cursor_overlay: boolean;
+	managed_browser: "helium" | "chrome";
 }
 
 export interface ComputerUseConfigSource {
@@ -25,6 +26,7 @@ const DEFAULT_CONFIG: ComputerUseConfig = {
 	browser_use: true,
 	headless: false,
 	cursor_overlay: true,
+	managed_browser: "helium",
 };
 
 let activeConfig: ComputerUseConfig = { ...DEFAULT_CONFIG };
@@ -50,6 +52,8 @@ function normalizePartial(raw: unknown): Partial<ComputerUseConfig> {
 	if (browserUse !== undefined) out.browser_use = browserUse;
 	if (headless !== undefined) out.headless = headless;
 	if (cursorOverlay !== undefined) out.cursor_overlay = cursorOverlay;
+	const managedBrowser = (source as any).managed_browser;
+	if (managedBrowser === "helium" || managedBrowser === "chrome") out.managed_browser = managedBrowser;
 	return out;
 }
 
@@ -71,6 +75,8 @@ function readEnv(): Partial<ComputerUseConfig> {
 	if (browserUse !== undefined) out.browser_use = browserUse;
 	if (headless !== undefined) out.headless = headless;
 	if (cursorOverlay !== undefined) out.cursor_overlay = cursorOverlay;
+	const managedBrowser = process.env.PI_COMPUTER_USE_MANAGED_BROWSER;
+	if (managedBrowser === "helium" || managedBrowser === "chrome") out.managed_browser = managedBrowser;
 	return out;
 }
 

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,16 +1,13 @@
-export type RootSelector = string | number;
+export type RootSelector = string;
 export type ImageMode = "auto" | "always" | "never";
 export type MouseButtonName = "left" | "right" | "middle";
 
 export interface ObserveTargetParams {
-	app?: string;
-	windowTitle?: string;
 	root?: RootSelector;
-	image?: ImageMode;
 }
 
 export interface FindParams {
-	query?: string;
+	text?: string;
 	app?: string;
 	bundleId?: string;
 	pid?: number;
@@ -20,7 +17,6 @@ export interface FindParams {
 
 export interface StateTargetParams {
 	stateId?: string;
-	image?: ImageMode;
 }
 
 export interface NavigateBrowserParams extends StateTargetParams {
@@ -28,9 +24,7 @@ export interface NavigateBrowserParams extends StateTargetParams {
 }
 
 export interface LaunchBrowserParams {
-	browser?: "helium" | "chrome";
 	url?: string;
-	port?: number;
 }
 
 export interface EvaluateBrowserParams {
@@ -40,14 +34,14 @@ export interface EvaluateBrowserParams {
 
 export interface ObserveParams extends ObserveTargetParams {
 	mode?: "semantic" | "visual" | "fused";
+	/** Internal capture override; not part of the model-facing schema. */
 	readText?: "auto" | "always" | "never";
 }
 
 export interface SearchUiParams extends StateTargetParams {
 	text?: string;
 	role?: string;
-	action?: string;
-	limit?: number;
+	capability?: string;
 }
 
 export interface ExpandUiParams extends StateTargetParams {
@@ -57,11 +51,20 @@ export interface ExpandUiParams extends StateTargetParams {
 
 export interface InspectUiParams extends StateTargetParams {
 	ref: string;
-	includeRaw?: boolean;
+}
+
+export interface UiCondition {
+	ref?: string;
+	scopeRef?: string;
+	text?: string;
+	role?: string;
+	value?: string;
+	until?: "present" | "absent";
+	timeoutMs?: number;
 }
 
 export interface UiAction {
-	action: "press" | "click" | "doubleClick" | "setText" | "typeText" | "keypress" | "scroll" | "drag" | "moveMouse" | "wait";
+	action: "press" | "click" | "setText" | "typeText" | "keypress" | "scroll" | "drag" | "moveMouse";
 	ref?: string;
 	x?: number;
 	y?: number;
@@ -72,35 +75,19 @@ export interface UiAction {
 	path?: Array<{ x: number; y: number } | [number, number]>;
 	button?: MouseButtonName;
 	clickCount?: number;
-	ms?: number;
 }
 
 export interface ActParams extends StateTargetParams {
 	actions: UiAction[];
-	/** Prohibits foreground fallback when true. Background is always attempted first. */
-	headless?: boolean;
-	/** Optional semantic postcondition checked before the transaction reports success. */
-	expect?: {
-		text?: string;
-		role?: string;
-		value?: string;
-		gone?: boolean;
-		timeoutMs?: number;
-	};
+	expect?: UiCondition;
 }
 
 export interface ReadTextParams extends StateTargetParams {
-	ref?: string;
+	ref: string;
 	offset?: number;
-	limit?: number;
 }
 
-export interface WaitForParams extends StateTargetParams {
-	text?: string;
-	role?: string;
-	gone?: boolean;
-	timeoutMs?: number;
-}
+export interface WaitForParams extends StateTargetParams, UiCondition {}
 
 export const AGENT_TOOL_NAMES = new Set([
 	"find_roots",

--- a/src/note.ts
+++ b/src/note.ts
@@ -180,10 +180,16 @@ export function noteRegionKeyForRef(outline: Outline, ref: string): string | und
 export function renderNote(note: WindowNote | undefined): string {
 	if (!note) return "";
 	const looked = note.lastLookId ? "looked just now" : "not looked";
-	const lines = [`note ${note.windowRef} ${JSON.stringify(note.title)} (pairing ${note.pairing}, ${looked})`];
-	for (const region of note.regions) {
-		const detail = region.detail ? `   (${region.detail})` : "";
-		lines.push(`  ${region.label.padEnd(14, " ")} ${region.status}${detail}`);
+	const lines = [`note ${note.windowRef} ${JSON.stringify(note.title.slice(0, 512))} (pairing ${note.pairing}, ${looked})`];
+	const visible = note.regions.slice(0, 64);
+	for (const region of visible) {
+		const detail = region.detail ? `   (${region.detail.slice(0, 256)})` : "";
+		lines.push(`  ${region.label.slice(0, 512).padEnd(14, " ")} ${region.status}${detail}`);
 	}
-	return lines.join("\n");
+	if (note.regions.length > visible.length) lines.push(`  … ${note.regions.length - visible.length} more note regions; use search_ui or expand_ui`);
+	const encoded = new TextEncoder().encode(lines.join("\n"));
+	if (encoded.byteLength <= 8 * 1024) return new TextDecoder().decode(encoded);
+	let end = 8 * 1024;
+	while (end > 0 && (encoded[end] & 0xc0) === 0x80) end -= 1;
+	return `${new TextDecoder().decode(encoded.subarray(0, end))}\n… note byte budget reached`;
 }

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -88,6 +88,8 @@ export interface OutlineSearchMatch {
 	label: string;
 	actions: string[];
 	path: string;
+	matchReason?: "exact" | "prefix" | "substring" | "fuzzy" | "filter";
+	score?: number;
 	node: OutlineNode;
 }
 
@@ -411,6 +413,63 @@ function actionMatches(node: OutlineNode, action: string): boolean {
 	return node.actions.some((candidate) => candidate.toLowerCase().includes(query));
 }
 
+function normalizedSearchRole(value: string): string {
+	return value.trim().toLowerCase().replace(/^ax/, "").replace(/[ _-]+/g, "");
+}
+
+function damerauLevenshtein(a: string, b: string): number {
+	const rows = a.length + 1;
+	const cols = b.length + 1;
+	const matrix = Array.from({ length: rows }, (_, i) => Array.from({ length: cols }, (_, j) => i === 0 ? j : j === 0 ? i : 0));
+	for (let i = 1; i < rows; i += 1) {
+		for (let j = 1; j < cols; j += 1) {
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+			matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost);
+			if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) matrix[i][j] = Math.min(matrix[i][j], matrix[i - 2][j - 2] + 1);
+		}
+	}
+	return matrix[a.length][b.length];
+}
+
+export function rankedTextMatch(values: string[], text: string): { reason: "exact" | "prefix" | "substring" | "fuzzy"; score: number } | undefined {
+	const query = text.toLowerCase().replace(/\s+/g, " ").trim().slice(0, 256);
+	if (!query) return undefined;
+	const candidates = values.map((value) => value.toLowerCase().replace(/\s+/g, " ").trim().slice(0, 512)).filter(Boolean);
+	if (candidates.some((value) => value === query)) return { reason: "exact", score: 1 };
+	if (candidates.some((value) => value.startsWith(query) || value.split(/\W+/).some((token) => token.startsWith(query)))) return { reason: "prefix", score: 0.95 };
+	if (candidates.some((value) => value.includes(query))) return { reason: "substring", score: 0.9 };
+	let score = 0;
+	for (const value of candidates) {
+		for (const candidate of [value, ...value.split(/\W+/)]) {
+			if (!candidate || candidate.length > 256) continue;
+			score = Math.max(score, 1 - damerauLevenshtein(query, candidate) / Math.max(query.length, candidate.length));
+		}
+	}
+	return score >= 0.72 ? { reason: "fuzzy", score } : undefined;
+}
+
+export function searchOutlineRanked(outline: Outline, text?: string, role?: string, capability?: string, limit = 12): { matches: OutlineSearchMatch[]; totalMatches: number } {
+	const query = text?.trim();
+	const roleQuery = role ? normalizedSearchRole(role) : undefined;
+	const actionQuery = capability?.trim();
+	const strong: Array<OutlineSearchMatch & { order: number }> = [];
+	const fuzzy: Array<OutlineSearchMatch & { order: number }> = [];
+	for (const [order, node] of outline.nodes.entries()) {
+		if (roleQuery && normalizedSearchRole(node.role) !== roleQuery) continue;
+		if (actionQuery && !actionMatches(node, actionQuery)) continue;
+		const label = outlineNodeLabel(node);
+		const match = query ? rankedTextMatch([label, node.identifier, node.title, node.description, node.value, ...node.text.map((item) => item.string)], query) : undefined;
+		if (query && !match) continue;
+		const result = { ref: node.ref, role: node.role, label, actions: node.actions, path: outlineNodePath(node), matchReason: match?.reason ?? "filter" as const, score: match?.score ?? 1, node, order };
+		(match?.reason === "fuzzy" ? fuzzy : strong).push(result);
+	}
+	const rank = { exact: 0, prefix: 1, substring: 2, filter: 3, fuzzy: 4 } as const;
+	const sorted = [...strong.sort((a, b) => rank[a.matchReason!] - rank[b.matchReason!] || b.score! - a.score! || a.order - b.order)];
+	const useFuzzy = sorted.length < limit;
+	if (useFuzzy) sorted.push(...fuzzy.sort((a, b) => b.score! - a.score! || a.order - b.order));
+	return { matches: sorted.slice(0, limit).map(({ order: _order, ...match }) => match), totalMatches: strong.length + (useFuzzy ? fuzzy.length : 0) };
+}
+
 export function searchOutline(outline: Outline, text?: string, role?: string, action?: string, limit = 50): OutlineSearchMatch[] {
 	const query = text?.trim().toLowerCase();
 	const roleQuery = role?.trim();
@@ -444,6 +503,11 @@ export function serializeOutline(outline: Outline): SerializedOutline {
 export function serializeOutlineNode(node: OutlineNode): SerializedOutlineNode {
 	const { parent: _parent, children, ...rest } = node;
 	return { ...rest, children: children.map(serializeOutlineNode) };
+}
+
+export function serializeOutlineNodeShallow(node: OutlineNode): SerializedOutlineNode {
+	const { parent: _parent, children: _children, ...rest } = node;
+	return { ...rest, children: [] };
 }
 
 export function restoreOutline(serialized: SerializedOutline): Outline {

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,0 +1,134 @@
+import { closeSync, mkdtempSync, openSync, readSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentToolResult } from "@earendil-works/pi-coding-agent";
+
+export const MODEL_TEXT_MAX_BYTES = 48 * 1024;
+export const MODEL_TEXT_MAX_LINES = 2_000;
+export const OUTPUT_PAGE_BYTES = 16 * 1024;
+export const UI_TEXT_PAGE_CHARS = 12 * 1024;
+export const MODEL_PREVIEW_BYTES = 16 * 1024;
+const OUTPUT_ENTRY_MAX_BYTES = 16 * 1024 * 1024;
+const OUTPUT_STORE_MAX_BYTES = 64 * 1024 * 1024;
+
+interface StoredOutput {
+	ref: string;
+	filePath: string;
+	storedBytes: number;
+	totalBytes: number;
+	complete: boolean;
+}
+
+const outputs = new Map<string, StoredOutput>();
+let outputDirectory: string | undefined;
+let outputBytes = 0;
+let nextOutputId = 1;
+
+function utf8Prefix(bytes: Uint8Array, maxBytes: number): Uint8Array {
+	if (bytes.byteLength <= maxBytes) return bytes;
+	let end = Math.max(0, maxBytes);
+	while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
+	return bytes.subarray(0, end);
+}
+
+function boundedPrefix(value: string, maxBytes: number, maxLines: number): string {
+	const lines = value.split("\n", maxLines + 1);
+	const lineBounded = lines.length > maxLines ? lines.slice(0, maxLines).join("\n") : value;
+	return new TextDecoder().decode(utf8Prefix(new TextEncoder().encode(lineBounded), maxBytes));
+}
+
+function storeOutput(value: string): StoredOutput {
+	const encoded = new TextEncoder().encode(value);
+	const stored = encoded.byteLength > OUTPUT_ENTRY_MAX_BYTES ? utf8Prefix(encoded, OUTPUT_ENTRY_MAX_BYTES) : encoded;
+	outputDirectory ??= mkdtempSync(path.join(os.tmpdir(), "pi-computer-use-output-"));
+	const ref = `@o${nextOutputId++}`;
+	const filePath = path.join(outputDirectory, `${ref.slice(2)}.txt`);
+	writeFileSync(filePath, stored, { mode: 0o600 });
+	const entry: StoredOutput = { ref, filePath, storedBytes: stored.byteLength, totalBytes: encoded.byteLength, complete: stored.byteLength === encoded.byteLength };
+	outputs.set(entry.ref, entry);
+	outputBytes += entry.storedBytes;
+	while (outputBytes > OUTPUT_STORE_MAX_BYTES && outputs.size > 1) {
+		const oldestRef = outputs.keys().next().value as string | undefined;
+		if (!oldestRef) break;
+		const oldest = outputs.get(oldestRef)!;
+		outputs.delete(oldestRef);
+		outputBytes -= oldest.storedBytes;
+		try { unlinkSync(oldest.filePath); } catch { /* already removed */ }
+	}
+	return entry;
+}
+
+function refinementFor(tool: string): string {
+	if (tool === "search_ui") return "use a more selective text, role, or capability predicate";
+	if (tool === "find_roots") return "use a more selective text, app, bundleId, pid, or kind filter";
+	if (tool === "evaluate_browser") return "return selected fields, an aggregate, or a smaller slice";
+	if (tool === "observe_ui" || tool === "expand_ui") return "use search_ui or expand a more specific ref";
+	return "request a smaller or more focused result";
+}
+
+export function applyOutputEnvelope<T>(tool: string, result: AgentToolResult<T>): AgentToolResult<T> {
+	const textParts = result.content.filter((part): part is Extract<(typeof result.content)[number], { type: "text" }> => part.type === "text");
+	const combined = textParts.map((part) => part.text).join("\n");
+	const bytes = new TextEncoder().encode(combined).byteLength;
+	const lines = combined === "" ? 0 : combined.split("\n").length;
+	if (bytes <= MODEL_TEXT_MAX_BYTES && lines <= MODEL_TEXT_MAX_LINES) return result;
+
+	const entry = storeOutput(combined);
+	const preview = boundedPrefix(combined, MODEL_PREVIEW_BYTES, MODEL_TEXT_MAX_LINES - 4);
+	const returnedBytes = new TextEncoder().encode(preview).byteLength;
+	const availability = entry.complete
+		? `continue: read_text({ ref: "${entry.ref}", offset: ${returnedBytes} })`
+		: `continue: read_text({ ref: "${entry.ref}", offset: ${returnedBytes} }); only the first ${entry.storedBytes} bytes were stored, so refine for the remainder`;
+	const trailer = [
+		`output truncated: returned ${returnedBytes} of ${entry.totalBytes} utf-8 bytes`,
+		`refine: ${refinementFor(tool)}`,
+		availability,
+	].join("\n");
+	const images = result.content.filter((part) => part.type === "image");
+	return { ...result, content: [{ type: "text", text: `${preview}\n\n${trailer}` }, ...images] };
+}
+
+export function boundToolError(tool: string, error: unknown): Error {
+	const message = error instanceof Error ? error.message : String(error);
+	const bytes = new TextEncoder().encode(message).byteLength;
+	const lines = message.split("\n").length;
+	if (bytes <= MODEL_TEXT_MAX_BYTES && lines <= MODEL_TEXT_MAX_LINES) return error instanceof Error ? error : new Error(message);
+	const entry = storeOutput(message);
+	const preview = boundedPrefix(message, MODEL_PREVIEW_BYTES, MODEL_TEXT_MAX_LINES - 4);
+	const returnedBytes = new TextEncoder().encode(preview).byteLength;
+	const storageNote = entry.complete ? "" : `; only the first ${entry.storedBytes} bytes were stored`;
+	return new Error(`${preview}\n\nerror truncated: returned ${returnedBytes} of ${entry.totalBytes} utf-8 bytes\nrefine: ${refinementFor(tool)}\ncontinue: read_text({ ref: "${entry.ref}", offset: ${returnedBytes} })${storageNote}`);
+}
+
+export function readStoredOutput(ref: string, offsetValue: unknown): { text: string; offset: number; limit: number; totalBytes: number; hasMore: boolean; complete: boolean } | undefined {
+	const entry = outputs.get(ref);
+	if (!entry) return undefined;
+	let offset = Math.min(entry.storedBytes, Math.max(0, Math.trunc(typeof offsetValue === "number" && Number.isFinite(offsetValue) ? offsetValue : 0)));
+	const requestedBytes = Math.min(entry.storedBytes - offset, OUTPUT_PAGE_BYTES + 4);
+	const buffer = new Uint8Array(Math.max(0, requestedBytes));
+	const fd = openSync(entry.filePath, "r");
+	try { if (buffer.byteLength > 0) readSync(fd, buffer, 0, buffer.byteLength, offset); } finally { closeSync(fd); }
+	let start = 0;
+	while (start < buffer.byteLength && (buffer[start] & 0xc0) === 0x80) start += 1;
+	offset += start;
+	const slice = utf8Prefix(buffer.subarray(start), OUTPUT_PAGE_BYTES);
+	const actualEnd = offset + slice.byteLength;
+	return {
+		text: new TextDecoder().decode(slice),
+		offset,
+		limit: slice.byteLength,
+		totalBytes: entry.totalBytes,
+		hasMore: actualEnd < entry.storedBytes,
+		complete: entry.complete,
+	};
+}
+
+export function clearStoredOutputs(): void {
+	outputs.clear();
+	if (outputDirectory) {
+		try { rmSync(outputDirectory, { recursive: true, force: true }); } catch { /* best-effort session cleanup */ }
+	}
+	outputDirectory = undefined;
+	outputBytes = 0;
+	nextOutputId = 1;
+}

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -185,9 +185,12 @@ export interface PlatformReadTextResponse {
 }
 
 export interface PlatformWaitForRequest extends PlatformTarget {
+	lookId?: string;
 	text?: string;
 	role?: string;
 	value?: string;
+	scopeRef?: string;
+	scopeExact?: boolean;
 	gone: boolean;
 	timeoutMs: number;
 }


### PR DESCRIPTION
## summary

- enforce a universal 48 kib / 2,000-line model-visible text ceiling, with 16 kib previews and immutable session-local `@o` continuations through `read_text`
- replace broad root and outline enumeration with fixed-size deterministic exact → prefix → substring → fuzzy ranking
- simplify target selection, action targeting, text paging, shared wait/expect conditions, and CDP browser lifecycle
- stop duplicating full outlines in cached query details and bound running-note rendering
- parallelize root enumeration and bump the breaking contract release to `0.5.0`

## model-contract changes

- `find_roots.query` becomes ranked `text`; unmatched queries return zero results and empty queries return a bounded top set
- `observe_ui` accepts only an exact issued `@r` root plus observation mode
- `search_ui` requires `text`, `role`, or `capability`, uses fixed top-k retrieval, and reports total/returned counts and match reasons
- `read_text` uses fixed pages and reads both state-owned `@e` refs and immutable `@o` output refs
- `wait_for` and `act_ui.expect` share scoped `ref` / `scopeRef` conditions with `present` / `absent` semantics
- action targets are unambiguous; `doubleClick` becomes `clickCount`, and fixed sleeps are removed from action batches
- `launch_browser` chooses browser and port from configuration, then returns an observed state directly
- `navigate_browser` and `evaluate_browser` are CDP-state-only; native browser windows use the generic UI tools

## bounded output

all tool results and thrown errors pass through the shared envelope. overflow is stored in a private disk-backed session store capped at 16 mib per entry and 64 mib per session. continuation pages are fixed, utf-8-safe, immutable, and cleaned up at session shutdown.

## validation

- `npm test`
- `npm run test:platform`
- `npm run test:windows-scripts`
- `cargo test` in `native/windows/bridge-rs`
- macos helper swift parse/typecheck through the invariant suite
