### PR TITLE
fix(platform): run helper setup from compiled hosts

### DIFF
--- a/src/platform/macos/helper.ts
+++ b/src/platform/macos/helper.ts
@@ -146,10 +146,11 @@ export class MacosHelperClient {
 			return;
 		}
 
-		// setup-helper syncs the installed helper version/signature once per session.
+		// Re-enter Electron and Bun standalone hosts as their JavaScript runtimes.
 		await runProcess(process.execPath, [SETUP_HELPER_SCRIPT, "--runtime"], HELPER_SETUP_TIMEOUT_MS, signal, {
 			...process.env,
 			ELECTRON_RUN_AS_NODE: "1",
+			BUN_BE_BUN: "1",
 		});
 		this.helperInstallChecked = true;
 

--- a/src/platform/windows/helper.ts
+++ b/src/platform/windows/helper.ts
@@ -73,7 +73,8 @@ export class WindowsHelperClient {
 
 	async ensureInstalled(signal?: AbortSignal): Promise<void> {
 		if ((await isExecutable(WINDOWS_HELPER_PATH)) && this.installChecked) return;
-		await runProcess(process.execPath, [SETUP_HELPER_SCRIPT, "--platform", "windows", "--runtime"], HELPER_SETUP_TIMEOUT_MS, signal, { ...process.env, ELECTRON_RUN_AS_NODE: "1" });
+		// Re-enter Electron and Bun standalone hosts as their JavaScript runtimes.
+		await runProcess(process.execPath, [SETUP_HELPER_SCRIPT, "--platform", "windows", "--runtime"], HELPER_SETUP_TIMEOUT_MS, signal, { ...process.env, ELECTRON_RUN_AS_NODE: "1", BUN_BE_BUN: "1" });
 		this.installChecked = true;
 		if (!(await isExecutable(WINDOWS_HELPER_PATH))) throw new Error(`Failed to install Windows helper at ${WINDOWS_HELPER_PATH}.`);
 	}


### PR DESCRIPTION
## summary

- re-enter bun standalone hosts such as omp as the bun cli with the documented `BUN_BE_BUN=1` environment variable
- retain `ELECTRON_RUN_AS_NODE=1` for electron hosts
- apply the same helper setup behavior on macos and windows without runtime probing or fallback subprocesses

## rationale

`process.execPath` identifies the executable that started the process; under compiled omp that is the omp binary rather than a plain javascript runtime. bun documents `BUN_BE_BUN=1` specifically for making a standalone executable act as the bun cli, and omp v16.5.2 uses the same mechanism for its own runtime subprocesses:

- https://bun.sh/docs/bundler/executables#act-as-the-bun-cli
- https://github.com/can1357/oh-my-pi/blob/7d02778c60f4b5db60f84bedbca79d6e64cb91f5/packages/utils/src/runtime-install.ts#L323-L329
- https://www.electronjs.org/docs/latest/api/environment-variables#electron_run_as_node

## verification

- reproduced the original failure with the released omp 16.5.2 arm64 binary
- verified `BUN_BE_BUN=1` runs an external `.mjs` entrypoint through that same released binary
- `npm test`
- `npm run test:platform`
- `npm run test:windows-scripts`
- `npm pack --dry-run`

fixes #25
