### PR TITLE
fix(macos): bound broad root discovery

### DIFF
--- a/native/macos/bridge.swift
+++ b/native/macos/bridge.swift
@@ -421,6 +421,7 @@ final class Bridge {
 	}
 
 	private func runServer(socketPath: String) {
+		_ = signal(SIGPIPE, SIG_IGN)
 		try? FileManager.default.createDirectory(atPath: (socketPath as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
 		// LaunchServices may race multiple `open -n` requests while the first
 		// daemon is still binding. Keep process ownership separate from socket
@@ -450,25 +451,27 @@ final class Bridge {
 		while true {
 			let client = accept(server, nil, nil)
 			if client < 0 { continue }
+			var noSigPipe: Int32 = 1
+			_ = setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout.size(ofValue: noSigPipe)))
 			Thread.detachNewThread { [weak self] in self?.processClient(client) }
 		}
 	}
 
 	private func processClient(_ client: Int32) {
-		let clientOutput = FileHandle(fileDescriptor: client, closeOnDealloc: true)
+		let clientInput = FileHandle(fileDescriptor: client, closeOnDealloc: true)
 		var buffer = Data()
 		let newline = Data([0x0A])
 		while true {
-			let data = clientOutput.availableData
+			let data = clientInput.availableData
 			if data.isEmpty { break }
 			buffer.append(data)
 			while let range = buffer.range(of: newline) {
 				let lineData = buffer.subdata(in: 0..<range.lowerBound)
 				buffer.removeSubrange(0..<range.upperBound)
-				if let line = String(data: lineData, encoding: .utf8), !line.isEmpty { handleLine(line, to: clientOutput) }
+				if let line = String(data: lineData, encoding: .utf8), !line.isEmpty { handleLine(line, to: client) }
 			}
 		}
-		clientOutput.closeFile()
+		clientInput.closeFile()
 	}
 
 	private func processBufferedInput() {
@@ -483,7 +486,7 @@ final class Bridge {
 		}
 	}
 
-	private func handleLine(_ line: String, to responseOutput: FileHandle? = nil) {
+	private func handleLine(_ line: String, to responseSocket: Int32? = nil) {
 		let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
 		guard !trimmed.isEmpty else { return }
 
@@ -503,7 +506,7 @@ final class Bridge {
 					"id": id,
 					"ok": true,
 					"result": result,
-				], to: responseOutput)
+				], to: responseSocket)
 			} catch let failure as BridgeFailure {
 				send([
 					"id": id,
@@ -512,7 +515,7 @@ final class Bridge {
 						"message": failure.message,
 						"code": failure.code,
 					],
-				], to: responseOutput)
+				], to: responseSocket)
 			} catch {
 				send([
 					"id": id,
@@ -521,7 +524,7 @@ final class Bridge {
 						"message": error.localizedDescription,
 						"code": "internal_error",
 					],
-				], to: responseOutput)
+				], to: responseSocket)
 			}
 		} catch let failure as BridgeFailure {
 			send([
@@ -531,7 +534,7 @@ final class Bridge {
 					"message": failure.message,
 					"code": failure.code,
 				],
-			], to: responseOutput)
+			], to: responseSocket)
 		} catch {
 			send([
 				"id": fallbackId,
@@ -540,20 +543,31 @@ final class Bridge {
 					"message": error.localizedDescription,
 					"code": "internal_error",
 				],
-			], to: responseOutput)
+			], to: responseSocket)
 		}
 	}
 
-	private func send(_ payload: [String: Any], to responseOutput: FileHandle? = nil) {
+	private func send(_ payload: [String: Any], to responseSocket: Int32? = nil) {
 		guard JSONSerialization.isValidJSONObject(payload),
 			let data = try? JSONSerialization.data(withJSONObject: payload),
-			let line = String(data: data, encoding: .utf8)
+			let line = String(data: data, encoding: .utf8),
+			let out = (line + "\n").data(using: .utf8)
 		else {
 			return
 		}
 
-		if let out = (line + "\n").data(using: .utf8) {
-			(responseOutput ?? output).write(out)
+		guard let responseSocket else {
+			try? output.write(contentsOf: out)
+			return
+		}
+		out.withUnsafeBytes { raw in
+			guard let base = raw.baseAddress else { return }
+			var offset = 0
+			while offset < raw.count {
+				let sent = Darwin.send(responseSocket, base.advanced(by: offset), raw.count - offset, 0)
+				if sent <= 0 { return }
+				offset += sent
+			}
 		}
 	}
 
@@ -903,7 +917,7 @@ final class Bridge {
 		// even when their windows are visible and AX-controllable. Add CGWindow
 		// owners as acquisition candidates so callers can still resolve by pid/title
 		// and then build the normal AX scene through listWindows(pid:).
-		for owner in cgWindowOwners() where owner.pid != getpid() && !seen.contains(owner.pid) && pidIsAlive(owner.pid) {
+		for owner in cgWindowOwners() + cgPopupMenuOwners() where owner.pid != getpid() && !seen.contains(owner.pid) && pidIsAlive(owner.pid) {
 			seen.insert(owner.pid)
 			output.append([
 				"appName": owner.name,
@@ -1111,25 +1125,40 @@ final class Bridge {
 		["pairing": ["confidence": pairing.confidence, "score": pairing.score], "sheetCount": sheetCount]
 	}
 
-	private func listRoots(pid: Int32?, title: String? = nil) throws -> [String: Any] {
-		let requestedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
-		let apps: [[String: Any]]
+	private func rootCandidateApps(pid: Int32?, title: String?) -> [[String: Any]] {
+		let apps = listApps()
 		if let pid {
-			apps = [["pid": Int(pid)]]
-		} else if !requestedTitle.isEmpty,
+			return apps.first(where: { ($0["pid"] as? Int) == Int(pid) }).map { [$0] }
+				?? [["pid": Int(pid)]]
+		}
+
+		let requestedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+		if !requestedTitle.isEmpty,
 			let entries = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] {
 			let matchingPids = Set(entries.compactMap { entry -> Int32? in
 				let candidate = ((entry[kCGWindowName as String] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 				guard candidate == requestedTitle || candidate.contains(requestedTitle) else { return nil }
 				return (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
 			})
-			apps = listApps().filter { app in
+			return apps.filter { app in
 				guard let rawPid = app["pid"] as? Int else { return false }
 				return matchingPids.contains(Int32(rawPid))
 			}
-		} else {
-			apps = listApps()
 		}
+
+		// Root discovery should cross AX only for processes that can own a
+		// controllable top-level surface. listApps intentionally remains broad for
+		// app resolution, while this preflight excludes WebKit/XPC children that
+		// cannot contribute roots and may not answer AX requests.
+		let ownerPids = Set((cgWindowOwners() + cgPopupMenuOwners()).map(\.pid))
+		return apps.filter { app in
+			guard let rawPid = app["pid"] as? Int else { return false }
+			return ownerPids.contains(Int32(rawPid))
+		}
+	}
+
+	private func listRoots(pid: Int32?, title: String? = nil) throws -> [String: Any] {
+		let apps = rootCandidateApps(pid: pid, title: title)
 		var roots: [[String: Any]] = []
 		for app in apps {
 			guard let rawPid = app["pid"] as? Int else { continue }
@@ -1142,9 +1171,13 @@ final class Bridge {
 				if let bundleId { root["bundleId"] = bundleId }
 				roots.append(root)
 			}
-			let menuElements = openMenuElements(pid: appPid)
-			for (index, candidate) in cgPopupMenuCandidates(pid: appPid).enumerated() {
-				let menuElement = index < menuElements.count ? menuElements[index] : nil
+			let popupCandidates = cgPopupMenuCandidates(pid: appPid)
+			let menuElements = popupCandidates.isEmpty ? [] : openMenuElements(pid: appPid)
+			let menuPairings = windowPairings(windows: menuElements, candidates: popupCandidates)
+			for candidate in popupCandidates {
+				let menuElement = menuElements.first {
+					menuPairings[ObjectIdentifier($0)]?.candidate?.windowId == candidate.windowId
+				}
 				let menuRef = menuElement.map { refStore.storeWindow($0) } ?? "cgmenu:\(candidate.windowId)"
 				var menu: [String: Any] = [
 					"kind": "menu",
@@ -2886,6 +2919,23 @@ final class Bridge {
 			)
 		}
 		return candidates
+	}
+
+	private func cgPopupMenuOwners() -> [CGWindowOwnerSummary] {
+		guard let entries = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] else {
+			return []
+		}
+		let popupLevel = Int(CGWindowLevelForKey(.popUpMenuWindow))
+		var seen = Set<Int32>()
+		return entries.compactMap { entry -> CGWindowOwnerSummary? in
+			let layer = (entry[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+			guard layer == popupLevel,
+				let pid = (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+				seen.insert(pid).inserted
+			else { return nil }
+			let name = (entry[kCGWindowOwnerName as String] as? String) ?? processName(pid: pid) ?? "Unknown App"
+			return CGWindowOwnerSummary(pid: pid, name: name)
+		}
 	}
 
 	private func cgPopupMenuCandidates(pid: Int32?) -> [CGWindowCandidate] {

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -221,6 +221,20 @@ check("INV-19 macOS root identity resolution", () => {
 	assert(swift.includes("($0[kCGWindowNumber as String] as? NSNumber)?.uint32Value == windowId"), "window lookup does not verify the returned stable ID");
 });
 
+check("INV-20 bounded broad root discovery", () => {
+	assert(swift.includes("private func rootCandidateApps"), "macOS helper lacks a root-candidate preflight");
+	assert(swift.includes("Set((cgWindowOwners() + cgPopupMenuOwners()).map(\\.pid))"), "broad root discovery is not bounded by top-level and popup-menu owners");
+	assert(swift.includes("for owner in cgWindowOwners() + cgPopupMenuOwners()"), "listApps omits menu-only accessory owners");
+	assert(swift.includes("popupCandidates.isEmpty ? [] : openMenuElements"), "root discovery traverses menus when no popup exists");
+	assert(swift.includes("let menuPairings = windowPairings(windows: menuElements, candidates: popupCandidates)"), "popup roots are paired by traversal order instead of geometry and identity evidence");
+	assert(ts.includes("async function rootsForFind"), "find_roots lacks a root-acquisition module");
+	assert(/if \(!query\.app && !query\.bundleId\)[\s\S]{0,160}listRoots\(\{\}, signal\)/.test(ts), "broad find_roots does not use one platform listRoots call");
+	assert(!ts.includes("collectWindowDetails(await listApps(signal)"), "broad root discovery still uses listApps as its acquisition seam");
+	assert(swift.includes("signal(SIGPIPE, SIG_IGN)"), "helper daemon does not ignore process-wide SIGPIPE");
+	assert(swift.includes("SO_NOSIGPIPE"), "helper sockets can terminate the daemon on a late response");
+	assert(swift.includes("Darwin.send(responseSocket"), "helper socket responses do not use failure-tolerant writes");
+});
+
 check("INV-8 swift typecheck", () => {
 	const triple = process.arch === "x64" ? "x86_64-apple-macosx14.0" : "arm64-apple-macosx14.0";
 	execFileSync("xcrun", [
@@ -262,6 +276,19 @@ function call(socketPath, payload, timeoutMs = 10000) {
 			clearTimeout(timer);
 			reject(error);
 		});
+	});
+}
+
+function abandon(socketPath, payload) {
+	return new Promise((resolve, reject) => {
+		const socket = net.createConnection(socketPath);
+		socket.on("connect", () => {
+			socket.write(`${JSON.stringify(payload)}\n`, () => {
+				socket.destroy();
+				resolve();
+			});
+		});
+		socket.on("error", reject);
 	});
 }
 
@@ -319,6 +346,21 @@ async function liveChecks() {
 		const socketPath = process.env.PI_CU_SOCKET_PATH ?? path.join(os.homedir(), "Library/Caches/pi-computer-use/bridge.sock");
 		const diagnostics = await call(socketPath, { id: "inv-diagnostics", cmd: "diagnostics" });
 		check("LIVE diagnostics current protocol", () => assert(diagnostics.protocolVersion === 6, `protocolVersion=${diagnostics.protocolVersion}`));
+		const broadDiscoveryStarted = Date.now();
+		const broadRoots = await call(socketPath, { id: "inv-broad-roots", cmd: "listRoots" }, 10000);
+		const broadDiscoveryMs = Date.now() - broadDiscoveryStarted;
+		const diagnosticsAfterBroadDiscovery = await call(socketPath, { id: "inv-diagnostics-after-broad-roots", cmd: "diagnostics" });
+		check("LIVE broad root discovery is bounded and keeps helper alive", () => {
+			assert(Array.isArray(broadRoots?.roots), "broad listRoots did not return roots");
+			assert(broadDiscoveryMs < 10000, `broad listRoots took ${broadDiscoveryMs}ms`);
+			assert(diagnosticsAfterBroadDiscovery.protocolVersion === 6, "helper did not survive broad listRoots");
+		});
+		await abandon(socketPath, { id: "inv-abandoned-roots", cmd: "listRoots" });
+		await new Promise((resolve) => setTimeout(resolve, Math.min(5000, Math.max(1000, broadDiscoveryMs * 2))));
+		const diagnosticsAfterAbandon = await call(socketPath, { id: "inv-diagnostics-after-abandon", cmd: "diagnostics" });
+		check("LIVE abandoned root discovery keeps helper alive", () => {
+			assert(diagnosticsAfterAbandon.protocolVersion === 6, "helper died after writing to an abandoned root-discovery socket");
+		});
 		const explicitWindowId = process.env.PI_CU_LIVE_WINDOW_ID ? Number(process.env.PI_CU_LIVE_WINDOW_ID) : undefined;
 		let windows = [];
 		try {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -889,27 +889,28 @@ async function resolveTargetByWindowSelector(selector: RootSelector, signal?: Ab
 	}
 
 	const numericWindowId = Number(normalized);
-	if (Number.isInteger(numericWindowId) && numericWindowId > 0) {
-		const apps = await listApps(signal);
-		for (const app of apps) {
-			const windows = await listWindows(app.pid, signal);
-			const match = windows.find((window) => window.windowId === numericWindowId);
-			if (match) {
-				assertBrowserUseAllowed(app);
-				const resolved = toResolvedTarget(app, match);
-				setCurrentTarget(resolved);
-				return resolved;
-			}
-		}
-		throw new Error(`Window id '${numericWindowId}' was not found. Call find_roots again and choose a current window.`);
-	}
-
 	if (normalized.startsWith("@r")) {
 		throw new Error(`Root ref '${normalized}' is not available in this session. Call find_roots first.`);
 	}
 
 	const config = getComputerUseConfig();
-	const candidates = await collectWindowDetails(await listApps(signal), config, signal);
+	const candidates = collectWindowDetails(await currentPlatformBackend.listRoots({}, signal), config);
+	if (Number.isInteger(numericWindowId) && numericWindowId > 0) {
+		const match = candidates.find((candidate) => candidate.windowId === numericWindowId);
+		if (!match) {
+			throw new Error(`Window id '${numericWindowId}' was not found. Call find_roots again and choose a current window.`);
+		}
+		const app: HelperApp = { appName: match.app, bundleId: match.bundleId, pid: match.pid };
+		assertBrowserUseAllowed(app);
+		const roots = await listWindows(match.pid, signal);
+		const helperRoot = roots.find((root) => root.windowId === numericWindowId) ?? roots[0];
+		if (!helperRoot) {
+			throw new Error(`Window id '${numericWindowId}' disappeared during resolution. Call find_roots again.`);
+		}
+		const resolved = toResolvedTarget(app, helperRoot);
+		setCurrentTarget(resolved);
+		return resolved;
+	}
 	const query = normalizeText(normalized);
 	const exact = candidates.filter((candidate) => normalizeText(candidate.app) === query || normalizeText(candidate.windowTitle) === query);
 	const fuzzy = exact.length > 0 ? exact : candidates.filter((candidate) => `${normalizeText(candidate.app)} ${normalizeText(candidate.windowTitle)}`.includes(query));
@@ -1446,40 +1447,62 @@ function rootDeltaLines(execution: ExecutionTrace): string[] {
 }
 
 // Side effect: stores stable @r refs for discovered windows in runtimeState.
-async function collectWindowDetails(apps: HelperApp[], config: ReturnType<typeof getComputerUseConfig>, signal?: AbortSignal): Promise<ListWindowsDetails["windows"]> {
+function collectWindowDetails(roots: HelperWindow[], config: ReturnType<typeof getComputerUseConfig>): ListWindowsDetails["windows"] {
 	const windows: ListWindowsDetails["windows"] = [];
-	for (const app of apps) {
-		const appWindows = await listWindows(app.pid, signal);
-		for (const window of appWindows) {
-			const storedRef = storeWindowRefForAppWindow(app, window);
-			windows.push({
-				app: app.appName,
-				bundleId: app.bundleId,
-				pid: app.pid,
-				kind: window.kind,
-				windowTitle: window.title || "(untitled)",
-				windowId: window.windowId,
-				windowRef: storedRef.ref,
-				nativeWindowRef: window.windowRef,
-				framePoints: window.framePoints,
-				scaleFactor: window.scaleFactor,
-				isMinimized: window.isMinimized,
-				isOnscreen: window.isOnscreen,
-				isMain: window.isMain,
-				isFocused: window.isFocused,
-				isModal: window.isModal,
-				sheetCount: platformRootSheetCount(window),
-				role: window.role,
-				subrole: window.subrole,
-				pairing: platformRootPairing(window),
-				zOrder: window.zOrder,
-				browserUseAllowed: config.browser_use || !currentPlatformBackend.isBrowserApp(app.appName, app.bundleId),
-				score: scoreWindow(window),
-			});
-		}
+	for (const window of roots) {
+		if (!window.pid) continue;
+		const app: HelperApp = {
+			appName: window.appName ?? "Unknown App",
+			bundleId: window.bundleId,
+			pid: window.pid,
+		};
+		const storedRef = storeWindowRefForAppWindow(app, window);
+		windows.push({
+			app: app.appName,
+			bundleId: app.bundleId,
+			pid: app.pid,
+			kind: window.kind,
+			windowTitle: window.title || "(untitled)",
+			windowId: window.windowId,
+			windowRef: storedRef.ref,
+			nativeWindowRef: window.windowRef,
+			framePoints: window.framePoints,
+			scaleFactor: window.scaleFactor,
+			isMinimized: window.isMinimized,
+			isOnscreen: window.isOnscreen,
+			isMain: window.isMain,
+			isFocused: window.isFocused,
+			isModal: window.isModal,
+			sheetCount: platformRootSheetCount(window),
+			role: window.role,
+			subrole: window.subrole,
+			pairing: platformRootPairing(window),
+			zOrder: window.zOrder,
+			browserUseAllowed: config.browser_use || !currentPlatformBackend.isBrowserApp(app.appName, app.bundleId),
+			score: scoreWindow(window),
+		});
 	}
 	windows.sort((a, b) => b.score - a.score || a.app.localeCompare(b.app) || a.windowTitle.localeCompare(b.windowTitle));
 	return windows;
+}
+
+async function rootsForFind(query: FindParams, signal?: AbortSignal): Promise<HelperWindow[]> {
+	if (Number.isFinite(query.pid)) {
+		return await currentPlatformBackend.listRoots({ pid: query.pid }, signal);
+	}
+	if (!query.app && !query.bundleId) {
+		return await currentPlatformBackend.listRoots({}, signal);
+	}
+
+	let apps = (await listApps(signal)).filter((app) => appMatchesWindowQuery(app, query));
+	if (query.app) {
+		const normalizedApp = normalizeText(query.app);
+		const exact = apps.filter((app) => normalizeText(app.appName) === normalizedApp);
+		if (exact.length > 0) apps = exact;
+	}
+	const roots: HelperWindow[] = [];
+	for (const app of apps) roots.push(...await listWindows(app.pid, signal));
+	return roots;
 }
 
 async function performListWindows(params: FindParams, signal?: AbortSignal): Promise<AgentToolResult<ListWindowsDetails>> {
@@ -1491,9 +1514,13 @@ async function performListWindows(params: FindParams, signal?: AbortSignal): Pro
 		pid: Number.isFinite(rawParams.pid) ? Math.trunc(rawParams.pid!) : undefined,
 		kind: rawParams.kind,
 	};
-	const matchingApps = (await listApps(signal)).filter((app) => appMatchesWindowQuery(app, query));
 	const config = getComputerUseConfig();
-	const desktopForest = await collectWindowDetails(matchingApps, config, signal);
+	const nativeRoots = await rootsForFind(query, signal);
+	const desktopForest = collectWindowDetails(nativeRoots, config).filter((root) => appMatchesWindowQuery({
+		appName: root.app,
+		bundleId: root.bundleId,
+		pid: root.pid,
+	}, query));
 	const browserForest: ListWindowsDetails["windows"] = query.pid || query.bundleId || query.app || !config.browser_use ? [] : (await listCdpPageContexts().catch(() => []))
 		.map((page) => ({
 			app: "Browser",


### PR DESCRIPTION
Fixes #28.

## What changed

- route broad desktop discovery through the existing platform `listRoots` seam once instead of issuing `listRoots(pid)` for every process returned by `listApps`;
- preflight unfiltered macOS root candidates from layer-0 and popup-menu WindowServer owners before crossing AX;
- keep explicit PID/app/bundle discovery available for AX-only and accessory targets;
- avoid deep AX menu traversal when no popup menu exists and pair popup roots by existing window evidence instead of traversal order;
- make socket response writes tolerate abandoned clients without terminating the helper on `SIGPIPE`;
- add static and live invariants for bounded broad discovery and abandoned-client liveness.

`listApps` keeps its existing broad semantics. Only unfiltered root acquisition receives the WindowServer preflight.

## Validation

- `npm run typecheck`
- `npm run test:schema`
- session lifecycle checks on Node 25
- runtime concurrency checks on Node 25
- static invariant suite
- native arm64 build
- live invariant suite against the rebuilt helper, including broad `listRoots`, abandoned socket, observation, hit testing, stale refs, and helper liveness
- Pi-level reproduction: unfiltered `find_roots` now completes; the canonical helper remains alive with Accessibility and Screen Recording granted

The repository's lifecycle/runtime npm scripts use `--experimental-transform-types`, which Node 26 no longer accepts, so those checks were run with Node 25.9.0.

## Permission impact

The implementation does not change requested permissions or TCC behavior. Local validation required re-signing the development helper; release users should continue receiving the normal release-signed helper.

## AI assistance

Pi assisted with diagnosis and implementation. I did not attach the full local session transcript because it contains private window metadata from live root discovery; the reproducible technical evidence is recorded in #28 and this PR.
