### PR TITLE
fix(macos): stop idle cursor redraws

### DIFF
--- a/native/macos/agent_cursor.swift
+++ b/native/macos/agent_cursor.swift
@@ -12,6 +12,9 @@ final class AgentCursor {
     private init() {}
 
     func animate(to point: CGPoint, above windowId: UInt32) {
+        idleHideTask?.cancel()
+        idleHideTask = nil
+
         let window = ensureWindow()
         if !window.isVisible { window.orderFrontRegardless() }
         window.order(.above, relativeTo: Int(windowId))
@@ -26,11 +29,17 @@ final class AgentCursor {
         }
         renderer.moveTo(point: point)
 
-        idleHideTask?.cancel()
-        idleHideTask = Task { @MainActor [weak self] in
+        idleHideTask = Task { @MainActor [weak self, weak window] in
             try? await Task.sleep(for: .seconds(8))
-            guard !Task.isCancelled else { return }
-            self?.overlay?.orderOut(nil)
+            guard !Task.isCancelled, let self, let window else { return }
+            guard self.overlay === window else { return }
+
+            renderer.cancelAnimation()
+            window.orderOut(nil)
+            window.contentView = nil
+            window.close()
+            overlay = nil
+            idleHideTask = nil
         }
     }
 
@@ -70,7 +79,7 @@ private struct AgentCursorView: View {
     @Bindable private var renderer = AgentCursorRenderer.shared
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 120.0)) { context in
+        TimelineView(.animation(minimumInterval: 1.0 / 120.0, paused: !renderer.isAnimating)) { context in
             Canvas { graphics, _ in
                 renderer.tick(now: context.date.timeIntervalSinceReferenceDate)
                 drawCursor(in: graphics)

--- a/native/macos/agent_cursor_motion.swift
+++ b/native/macos/agent_cursor_motion.swift
@@ -10,6 +10,7 @@ final class AgentCursorRenderer {
 
     private(set) var position = CGPoint(x: -200, y: -200)
     private(set) var heading: Double = .pi / 4
+    private(set) var isAnimating = false
 
     private var path: PlannedPath?
     private var spring: Spring?
@@ -30,18 +31,26 @@ final class AgentCursorRenderer {
         spring = nil
         springTarget = nil
         distanceSoFar = 0
+        lastFrameTime = nil
+        isAnimating = true
     }
 
     func setInitialPosition(_ point: CGPoint) {
         position = point
+        cancelAnimation()
+    }
+
+    func cancelAnimation() {
         path = nil
         spring = nil
         springTarget = nil
         distanceSoFar = 0
         lastFrameTime = nil
+        isAnimating = false
     }
 
     func tick(now: CFTimeInterval) {
+        guard isAnimating else { return }
         let previous = lastFrameTime ?? now
         let dt = min(0.05, now - previous)
         lastFrameTime = now
@@ -85,6 +94,8 @@ final class AgentCursorRenderer {
                 position = target.point
                 self.spring = nil
                 springTarget = nil
+                lastFrameTime = nil
+                isAnimating = false
             } else {
                 self.spring = spring
             }

--- a/native/macos/agent_cursor_motion_tests.swift
+++ b/native/macos/agent_cursor_motion_tests.swift
@@ -1,0 +1,65 @@
+import CoreGraphics
+import Foundation
+
+@main
+struct AgentCursorMotionTests {
+    @MainActor
+    static func main() {
+        let renderer = AgentCursorRenderer()
+        renderer.setInitialPosition(CGPoint(x: 100, y: 100))
+
+        expect(!renderer.isAnimating, "renderer should start idle")
+
+        renderer.moveTo(point: CGPoint(x: 500, y: 400))
+        expect(renderer.isAnimating, "renderer should become active when motion starts")
+
+        var now: CFTimeInterval = 0
+        for _ in 0..<12_000 where renderer.isAnimating {
+            now += 1.0 / 120.0
+            renderer.tick(now: now)
+        }
+
+        expect(!renderer.isAnimating, "renderer should become idle after motion settles")
+
+        renderer.moveTo(point: CGPoint(x: 800, y: 600))
+        renderer.tick(now: now + 1.0 / 120.0)
+        let stoppedPosition = renderer.position
+
+        renderer.cancelAnimation()
+        expect(!renderer.isAnimating, "cancelled motion should become idle")
+
+        renderer.tick(now: now + 1)
+        expect(renderer.position == stoppedPosition, "idle ticks should not change the cancelled position")
+
+        renderer.setInitialPosition(CGPoint(x: 100, y: 100))
+        renderer.moveTo(point: CGPoint(x: 300, y: 300))
+        for _ in 0..<12 {
+            now += 1.0 / 120.0
+            renderer.tick(now: now)
+        }
+        let latestTarget = CGPoint(x: 900, y: 700)
+        renderer.moveTo(point: latestTarget)
+        for _ in 0..<12_000 where renderer.isAnimating {
+            now += 1.0 / 120.0
+            renderer.tick(now: now)
+        }
+
+        let endpointOffset = CGFloat(cos(Double.pi / 4) * 16)
+        let expectedPosition = CGPoint(
+            x: latestTarget.x + endpointOffset,
+            y: latestTarget.y + endpointOffset
+        )
+        expect(distance(renderer.position, expectedPosition) < 0.001, "latest target should supersede in-flight motion")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            FileHandle.standardError.write(Data("FAIL: \(message)\n".utf8))
+            exit(1)
+        }
+    }
+
+    private static func distance(_ lhs: CGPoint, _ rhs: CGPoint) -> CGFloat {
+        hypot(lhs.x - rhs.x, lhs.y - rhs.y)
+    }
+}

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -8,6 +8,8 @@ import { countOutlineNodes, foldToBudget, graftScopedOutline, nodeByRef, parseLo
 
 const root = path.resolve(new URL("..", import.meta.url).pathname);
 const swift = fs.readFileSync(path.join(root, "native/macos/bridge.swift"), "utf8");
+const agentCursorSwift = fs.readFileSync(path.join(root, "native/macos/agent_cursor.swift"), "utf8");
+const agentCursorMotionSwift = fs.readFileSync(path.join(root, "native/macos/agent_cursor_motion.swift"), "utf8");
 const ts = fs.readFileSync(path.join(root, "src/bridge.ts"), "utf8");
 const noteTs = fs.readFileSync(path.join(root, "src/note.ts"), "utf8");
 const configTs = fs.readFileSync(path.join(root, "src/config.ts"), "utf8");
@@ -195,6 +197,11 @@ check("INV-17 macOS agent cursor stays native, configurable, and headless-safe",
 	assert(swift.includes("app.processIdentifier != getpid()"), "helper overlay can leak into root discovery");
 	assert(swift.includes("AgentCursor.shared.animate(to:"), "native grounded actions do not drive the agent cursor");
 	assert(!swift.includes("completed.wait()") && !swift.includes("agentCursorLock"), "agent cursor can delay action delivery");
+	assert(agentCursorMotionSwift.includes("private(set) var isAnimating"), "agent cursor renderer does not expose active motion state");
+	assert(agentCursorSwift.includes("paused: !renderer.isAnimating"), "agent cursor timeline continues rendering while idle");
+	assert(agentCursorSwift.includes("renderer.cancelAnimation()"), "agent cursor timeout does not cancel in-flight rendering");
+	assert(agentCursorSwift.includes("guard self.overlay === window else { return }"), "stale agent cursor timeout can tear down a newer overlay");
+	assert(agentCursorSwift.includes("window.contentView = nil") && agentCursorSwift.includes("window.close()") && agentCursorSwift.includes("overlay = nil"), "agent cursor timeout retains its offscreen view tree");
 });
 
 check("INV-18 consolidated actions and diff-first resulting views", () => {
@@ -236,6 +243,23 @@ check("INV-8 swift typecheck", () => {
 		"native/macos/agent_cursor_motion.swift",
 		"native/macos/bridge.swift",
 	], { cwd: root, stdio: "pipe" });
+});
+
+check("INV-17 macOS agent cursor motion lifecycle", () => {
+	const triple = process.arch === "x64" ? "x86_64-apple-macosx14.0" : "arm64-apple-macosx14.0";
+	const binary = path.join(os.tmpdir(), `pi-computer-use-cursor-motion-tests-${process.pid}`);
+	try {
+		execFileSync("xcrun", [
+			"swiftc", "-target", triple, "-parse-as-library",
+			"-module-cache-path", path.join(os.tmpdir(), `pi-computer-use-cursor-test-cache-${process.arch}`),
+			"native/macos/agent_cursor_motion.swift",
+			"native/macos/agent_cursor_motion_tests.swift",
+			"-o", binary,
+		], { cwd: root, stdio: "pipe" });
+		execFileSync(binary, [], { cwd: root, stdio: "pipe" });
+	} finally {
+		fs.rmSync(binary, { force: true });
+	}
 });
 
 function call(socketPath, payload, timeoutMs = 10000) {


### PR DESCRIPTION
Fixes #32.

## Summary

- pause the macOS cursor timeline after motion settles;
- cancel stale hide tasks and release the offscreen overlay view/window at the idle timeout;
- preserve cursor recreation and latest-target behavior;
- add deterministic Swift lifecycle coverage and native source invariants.

## Root cause

The full-display SwiftUI overlay used an unconditional 120 Hz `TimelineView`. The idle timeout only called `orderOut(nil)`, leaving the retained `NSHostingView` and renderer scheduled after the window became offscreen.

## User impact

The agent cursor keeps its current appearance, default-enabled configuration, and eight-second linger. Active motion remains 120 Hz. Once motion settles, the helper stops its animation work; after the idle timeout, the overlay is fully released.

Permissions, browser behavior, public tool/configuration/protocol surfaces, and strict AX/headless suppression are unchanged.

## Validation

- `npm test`
- `npm run test:platform`
- `npm run test:windows-scripts`
- `npm run build:native -- --arch arm64 --output /tmp/pi-cu-cursor-idle-bridge --no-sign`
- `PI_CU_LIVE=1 PI_CU_SOCKET_PATH=<patched-socket> npm run test:invariants`
- `npm run test:commits -- upstream/main..HEAD`
- `git diff --check`
- live signed-helper validation on macOS 26.5.2 arm64:
  - the settled visible cursor reduced helper CPU to 0% after the brief active animation;
  - the overlay remained onscreen through the idle interval and was released after eight seconds;
  - after timeout, the helper owned zero windows and a five-second sample contained no cursor, timeline, Canvas, or display-cycle stack;
  - a later action recreated the overlay;
  - `cursorOverlay: false` and strict AX-only actions created no overlay.

Cubench was not run because the documented `../cubench` checkout is not available in this environment and no matching public checkout was discoverable.