### PR TITLE
fix(macos): install helper per user

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,13 @@ If you change native code, rebuild the helper:
 npm run build:native
 ```
 
-macOS permissions should be granted to:
+macOS permissions should normally be granted to:
 
 ```text
-/Applications/pi-computer-use.app
+~/Applications/pi-computer-use.app
 ```
+
+Existing writable system-wide installs remain at `/Applications/pi-computer-use.app`.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ pi install npm:@injaneity/pi-computer-use
 
 Start Pi and complete the platform setup flow.
 
-On macOS, grant permissions to:
+On macOS, the helper is installed per user by default. Grant permissions to:
 
 ```text
-/Applications/pi-computer-use.app
+~/Applications/pi-computer-use.app
 ```
+
+Existing writable system-wide installs remain at `/Applications/pi-computer-use.app`.
 
 Required macOS permissions:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,13 +76,13 @@ The adapter uses Cubench only for the instruction and final oracle; UI observati
 
 ## Native platform helpers
 
-On macOS, the helper installed for permissions is:
+On macOS, the helper installed for permissions is normally:
 
 ```text
-/Applications/pi-computer-use.app
+~/Applications/pi-computer-use.app
 ```
 
-The macOS helper targets macOS 14+ and uses ScreenCaptureKit. Local development can use ad-hoc signing. Release builds must use the release workflow so the helper app is signed with the stable release certificate.
+Existing writable system-wide installs remain at `/Applications/pi-computer-use.app`. The macOS helper targets macOS 14+ and uses ScreenCaptureKit. Local development can use ad-hoc signing. Release builds must use the release workflow so the helper app is signed with the stable release certificate.
 
 On Windows, development uses the Windows platform backend/helper and the active desktop session rather than the macOS app bundle or TCC permission model.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Platform setup
 
-macOS uses an installed helper app and TCC permissions. Windows support uses the active desktop session and Windows accessibility/input APIs; it does not use `/Applications/pi-computer-use.app` or the macOS TCC permission flow.
+macOS uses an installed helper app and TCC permissions. Windows support uses the active desktop session and Windows accessibility/input APIs; it does not use the macOS helper app or TCC permission flow.
 
 ## macOS helper app is missing
 
@@ -19,15 +19,17 @@ npm run build:native
 node scripts/setup-helper.mjs --force
 ```
 
-The helper app should exist at:
+The helper app should normally exist at:
 
 ```text
-/Applications/pi-computer-use.app
+~/Applications/pi-computer-use.app
 ```
+
+Existing writable system-wide installs remain at `/Applications/pi-computer-use.app`. Set `PI_COMPUTER_USE_HELPER_APP_PATH` only when an explicit location is needed for development or testing.
 
 ## macOS permissions fail
 
-Grant these permissions to `/Applications/pi-computer-use.app`:
+Grant these permissions to the resolved `pi-computer-use.app`, normally `~/Applications/pi-computer-use.app`:
 
 - Accessibility
 - Screen Recording, shown as Screen and System Audio Recording on newer macOS versions

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"test:platform": "node --experimental-strip-types scripts/check-platform-windows.mjs",
 		"test:windows-scripts": "node scripts/check-windows-build-scripts.mjs",
 		"test:signing": "node scripts/check-local-signing.mjs",
-		"test": "npm run typecheck && npm run test:schema && npm run test:output && npm run test:lifecycle && npm run test:runtime && npm run test:invariants && npm run test:signing",
+		"test:macos-path": "node scripts/check-macos-helper-path.mjs",
+		"test": "npm run typecheck && npm run test:schema && npm run test:output && npm run test:lifecycle && npm run test:runtime && npm run test:invariants && npm run test:signing && npm run test:macos-path",
 		"build:native": "node scripts/build-native.mjs",
 		"build:windows": "node scripts/build-native.mjs --platform windows"
 	},

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -12,6 +12,7 @@ const ts = fs.readFileSync(path.join(root, "src/bridge.ts"), "utf8");
 const noteTs = fs.readFileSync(path.join(root, "src/note.ts"), "utf8");
 const configTs = fs.readFileSync(path.join(root, "src/config.ts"), "utf8");
 const setupHelper = fs.readFileSync(path.join(root, "scripts/setup-helper.mjs"), "utf8");
+const macosHelperPath = fs.readFileSync(path.join(root, "src/platform/macos/helper-path.mjs"), "utf8");
 const srcFiles = fs.readdirSync(path.join(root, "src"), { recursive: true })
 	.filter((file) => typeof file === "string" && file.endsWith(".ts"))
 	.map((file) => [file, fs.readFileSync(path.join(root, "src", file), "utf8")]);
@@ -185,7 +186,8 @@ check("INV-16 clean headless contract and non-destructive helper install", () =>
 	assert(!/stealth_mode|stealthMode|PI_COMPUTER_USE_STEALTH|PI_COMPUTER_USE_STRICT_AX/.test(configTs), "obsolete stealth configuration aliases remain");
 	assert(!/tccutil[\s\S]{0,80}reset|resetTcc/i.test(setupHelper), "helper installation can reset macOS privacy grants");
 	assert(setupHelper.includes("pi-computer-use Local Signing (com.injaneity.pi-computer-use)"), "stable bundle-specific local signing identity is missing");
-	assert(setupHelper.includes("PI_COMPUTER_USE_HELPER_APP_PATH"), "helper installer lacks an isolated test destination");
+	assert(macosHelperPath.includes("PI_COMPUTER_USE_HELPER_APP_PATH"), "helper installer lacks an isolated test destination");
+	assert(setupHelper.includes("resolveMacosHelperAppPath"), "helper installer bypasses shared macOS path resolution");
 });
 
 check("INV-17 macOS agent cursor stays native, configurable, and headless-safe", () => {

--- a/scripts/check-macos-helper-path.mjs
+++ b/scripts/check-macos-helper-path.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import { resolveMacosHelperAppPath } from "../src/platform/macos/helper-path.mjs";
+
+const homeDir = path.join(path.sep, "Users", "standard-user");
+const systemHelperAppPath = path.join(path.sep, "Applications", "pi-computer-use.app");
+const userHelperAppPath = path.join(homeDir, "Applications", "pi-computer-use.app");
+
+assert.equal(
+	resolveMacosHelperAppPath({ env: { PI_COMPUTER_USE_HELPER_APP_PATH: "/tmp/custom-helper.app" }, homeDir }),
+	"/tmp/custom-helper.app",
+	"explicit helper path should win",
+);
+
+assert.equal(
+	resolveMacosHelperAppPath({ env: {}, homeDir, systemHelperAppPath, fileExists: () => false }),
+	userHelperAppPath,
+	"fresh installs should use the per-user Applications directory",
+);
+
+assert.equal(
+	resolveMacosHelperAppPath({ env: {}, homeDir, systemHelperAppPath, fileExists: () => true, directoryIsWritable: () => true }),
+	systemHelperAppPath,
+	"existing writable system installs should remain in place",
+);
+
+assert.equal(
+	resolveMacosHelperAppPath({ env: {}, homeDir, systemHelperAppPath, fileExists: () => true, directoryIsWritable: () => false }),
+	userHelperAppPath,
+	"standard users should migrate away from a non-writable system install",
+);
+
+console.log("macos helper path checks passed");

--- a/scripts/setup-helper.mjs
+++ b/scripts/setup-helper.mjs
@@ -10,11 +10,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveMacosHelperAppPath } from "../src/platform/macos/helper-path.mjs";
 
 const execFile = promisify(execFileCallback);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const defaultHelperAppPath = "/Applications/pi-computer-use.app";
-const helperAppPath = process.env.PI_COMPUTER_USE_HELPER_APP_PATH || defaultHelperAppPath;
+const helperAppPath = resolveMacosHelperAppPath();
 const helperAppExecutablePath = path.join(helperAppPath, "Contents", "MacOS", "bridge");
 const helperSourceHashPath = path.join(helperAppPath, "Contents", "Resources", "source.sha256");
 const helperBundleId = "com.injaneity.pi-computer-use";
@@ -347,14 +347,19 @@ async function helperHasAdhocSignature() {
 }
 
 async function registerHelperApp() {
-	if (helperAppPath !== defaultHelperAppPath) return;
 	const lsregister = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
 	if (!(await exists(lsregister))) return;
 	await run(lsregister, ["-f", helperAppPath]).catch(() => {});
 }
 
+async function ensureHelperParentDirectory() {
+	const parentPath = path.dirname(helperAppPath);
+	await fs.mkdir(parentPath, { recursive: true });
+	await fs.access(parentPath, fsConstants.W_OK);
+}
+
 async function installPrebuiltHelperApp(sourceAppPath) {
-	await fs.access(path.dirname(helperAppPath), fsConstants.W_OK);
+	await ensureHelperParentDirectory();
 	const sourceExecutablePath = path.join(sourceAppPath, "Contents", "MacOS", "bridge");
 	const sourceInfoPath = path.join(sourceAppPath, "Contents", "Info.plist");
 	const existingExecutable = await fs.readFile(helperAppExecutablePath).catch(() => undefined);
@@ -379,7 +384,7 @@ async function installPrebuiltHelperApp(sourceAppPath) {
 }
 
 async function installHelperApp(sourcePath) {
-	await fs.access(path.dirname(helperAppPath), fsConstants.W_OK);
+	await ensureHelperParentDirectory();
 	const version = await packageVersion();
 	const infoPlistPath = path.join(helperAppPath, "Contents", "Info.plist");
 	const infoPlist = `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/platform/macos/helper-path.d.mts
+++ b/src/platform/macos/helper-path.d.mts
@@ -1,6 +1,3 @@
-export const HELPER_APP_NAME: string;
-export const SYSTEM_HELPER_APP_PATH: string;
-
 export interface MacosHelperPathOptions {
 	env?: NodeJS.ProcessEnv;
 	homeDir?: string;

--- a/src/platform/macos/helper-path.d.mts
+++ b/src/platform/macos/helper-path.d.mts
@@ -1,0 +1,12 @@
+export const HELPER_APP_NAME: string;
+export const SYSTEM_HELPER_APP_PATH: string;
+
+export interface MacosHelperPathOptions {
+	env?: NodeJS.ProcessEnv;
+	homeDir?: string;
+	systemHelperAppPath?: string;
+	fileExists?: (filePath: string) => boolean;
+	directoryIsWritable?: (directoryPath: string) => boolean;
+}
+
+export function resolveMacosHelperAppPath(options?: MacosHelperPathOptions): string;

--- a/src/platform/macos/helper-path.mjs
+++ b/src/platform/macos/helper-path.mjs
@@ -1,0 +1,34 @@
+import { accessSync, constants as fsConstants, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const HELPER_APP_NAME = "pi-computer-use.app";
+export const SYSTEM_HELPER_APP_PATH = path.join("/Applications", HELPER_APP_NAME);
+
+/**
+ * Resolve one stable helper location for both installation and runtime use.
+ * Existing writable system installs stay in place; all other installs are
+ * per-user so standard macOS accounts never require administrator access.
+ */
+export function resolveMacosHelperAppPath(options = {}) {
+	const env = options.env ?? process.env;
+	const explicitPath = env.PI_COMPUTER_USE_HELPER_APP_PATH?.trim();
+	if (explicitPath) return path.resolve(explicitPath);
+
+	const homeDir = options.homeDir ?? os.homedir();
+	const systemHelperAppPath = options.systemHelperAppPath ?? SYSTEM_HELPER_APP_PATH;
+	const fileExists = options.fileExists ?? existsSync;
+	const directoryIsWritable = options.directoryIsWritable ?? ((directoryPath) => {
+		try {
+			accessSync(directoryPath, fsConstants.W_OK);
+			return true;
+		} catch {
+			return false;
+		}
+	});
+
+	if (fileExists(systemHelperAppPath) && directoryIsWritable(path.dirname(systemHelperAppPath))) {
+		return systemHelperAppPath;
+	}
+	return path.join(homeDir, "Applications", HELPER_APP_NAME);
+}

--- a/src/platform/macos/helper-path.mjs
+++ b/src/platform/macos/helper-path.mjs
@@ -2,8 +2,8 @@ import { accessSync, constants as fsConstants, existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-export const HELPER_APP_NAME = "pi-computer-use.app";
-export const SYSTEM_HELPER_APP_PATH = path.join("/Applications", HELPER_APP_NAME);
+const HELPER_APP_NAME = "pi-computer-use.app";
+const SYSTEM_HELPER_APP_PATH = path.join("/Applications", HELPER_APP_NAME);
 
 /**
  * Resolve one stable helper location for both installation and runtime use.

--- a/src/platform/macos/helper.ts
+++ b/src/platform/macos/helper.ts
@@ -1,19 +1,20 @@
 import { spawn } from "node:child_process";
 import { constants as fsConstants } from "node:fs";
-import { access, mkdir } from "node:fs/promises";
+import { access, mkdir, realpath } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { toBoolean, toFiniteNumber, toOptionalString } from "../coerce.ts";
 import type { PlatformDiagnostics } from "../types.ts";
+import { resolveMacosHelperAppPath } from "./helper-path.mjs";
 
 const COMMAND_TIMEOUT_MS = 15_000;
 const HELPER_PROTOCOL_VERSION = 6;
 const HELPER_SETUP_TIMEOUT_MS = 60_000;
 
 export const HELPER_BUNDLE_ID = "com.injaneity.pi-computer-use";
-export const HELPER_APP_PATH = "/Applications/pi-computer-use.app";
+export const HELPER_APP_PATH = resolveMacosHelperAppPath();
 export const HELPER_APP_EXECUTABLE_PATH = path.join(HELPER_APP_PATH, "Contents", "MacOS", "bridge");
 const DEFAULT_HELPER_SOCKET_PATH = path.join(os.homedir(), "Library", "Caches", "pi-computer-use", "bridge.sock");
 export const HELPER_SOCKET_PATH = process.env.PI_CU_SOCKET_PATH ?? DEFAULT_HELPER_SOCKET_PATH;
@@ -62,6 +63,15 @@ async function isExecutable(filePath: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+async function isResolvedHelperExecutable(filePath?: string): Promise<boolean> {
+	if (!filePath) return true;
+	const [actualPath, expectedPath] = await Promise.all([
+		realpath(filePath).catch(() => path.resolve(filePath)),
+		realpath(HELPER_APP_EXECUTABLE_PATH).catch(() => path.resolve(HELPER_APP_EXECUTABLE_PATH)),
+	]);
+	return actualPath === expectedPath;
 }
 
 export async function runProcess(
@@ -162,7 +172,9 @@ export class MacosHelperClient {
 	async launchDaemon(signal?: AbortSignal): Promise<void> {
 		if (usingExternalHelperSocket) throw new HelperTransportError(`External helper socket is unavailable at ${HELPER_SOCKET_PATH}.`);
 		await mkdir(path.dirname(HELPER_SOCKET_PATH), { recursive: true });
-		await runProcess("open", ["-n", "-g", "-b", HELPER_BUNDLE_ID, "--args", "serve", "--socket", HELPER_SOCKET_PATH], COMMAND_TIMEOUT_MS, signal);
+		// Open the resolved bundle directly so a legacy system-wide copy with the
+		// same bundle id cannot win LaunchServices resolution.
+		await runProcess("open", ["-n", "-g", HELPER_APP_PATH, "--args", "serve", "--socket", HELPER_SOCKET_PATH], COMMAND_TIMEOUT_MS, signal);
 	}
 
 	async daemonCommand<T>(cmd: string, args: Record<string, unknown>, timeoutMs: number, signal?: AbortSignal): Promise<T> {
@@ -259,17 +271,21 @@ export class MacosHelperClient {
 
 	async ensureProtocol(signal?: AbortSignal): Promise<PlatformDiagnostics> {
 		let diagnostics = await this.diagnosticsCommand(signal);
-		if (diagnostics.protocolVersion === HELPER_PROTOCOL_VERSION) return diagnostics;
+		const executableMatches = await isResolvedHelperExecutable(diagnostics.executablePath);
+		if (diagnostics.protocolVersion === HELPER_PROTOCOL_VERSION && executableMatches) return diagnostics;
 
 		// The helper daemon outlives Pi, so restarting/reloading Pi alone does not
-		// replace a daemon that is still serving the previous installed binary.
+		// replace a stale daemon or one launched from the legacy system location.
 		// Stop it through the backwards-compatible command channel and relaunch
-		// the app that ensureInstalled() has just synced to /Applications.
+		// the exact app bundle that ensureInstalled() resolved.
 		await this.restart(signal);
 		diagnostics = await this.diagnosticsCommand(signal);
-		if (diagnostics.protocolVersion !== HELPER_PROTOCOL_VERSION) {
+		const relaunchedExecutableMatches = await isResolvedHelperExecutable(diagnostics.executablePath);
+		if (diagnostics.protocolVersion !== HELPER_PROTOCOL_VERSION || !relaunchedExecutableMatches) {
 			this.daemonAvailable = false;
-			throw new Error(`pi-computer-use helper protocol mismatch after relaunch: expected ${HELPER_PROTOCOL_VERSION}, got ${diagnostics.protocolVersion}. Reinstall or rebuild the helper app at ${HELPER_APP_PATH}.`);
+			throw new Error(
+				`pi-computer-use helper mismatch after relaunch: expected protocol ${HELPER_PROTOCOL_VERSION} and executable ${HELPER_APP_EXECUTABLE_PATH}; got protocol ${diagnostics.protocolVersion} and executable ${diagnostics.executablePath ?? "unknown"}. Reinstall or rebuild the helper app at ${HELPER_APP_PATH}.`,
+			);
 		}
 		return diagnostics;
 	}


### PR DESCRIPTION
## summary

- install new macos helpers under `~/Applications` so standard accounts don't need administrator access
- keep existing writable `/Applications` installs in place for backward compatibility
- share path resolution between setup and runtime, register either location, and launch the exact resolved bundle
- restart a daemon running from a different helper location
- document the resolved location and cover fresh, legacy, non-writable, and overridden paths

## root cause

helper installation and runtime lookup were hard-coded to `/Applications/pi-computer-use.app`. standard users can't write to `/Applications`, so postinstall silently skipped helper setup and the first desktop tool failed with `EACCES`.

reproduction: https://pi.dev/session/#6f65025986cb1d31eee933738f4c73ba

## validation

- `npm test`
- isolated runtime installation into a temporary `Applications` directory, including executable verification
- `npm pack --dry-run` confirms the shared runtime module and declaration are published
