### PR TITLE
fix(core): keep wait details json safe

### DIFF
--- a/scripts/check-bounded-output.mjs
+++ b/scripts/check-bounded-output.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { applyOutputEnvelope, boundToolError, clearStoredOutputs, MODEL_TEXT_MAX_BYTES, readStoredOutput } from "../src/output.ts";
-import { searchOutlineRanked } from "../src/outline.ts";
+import { searchOutlineRanked, serializeOutlineSearchMatch } from "../src/outline.ts";
 
 clearStoredOutputs();
 const oversized = "🙂".repeat(30_000);
@@ -29,6 +29,12 @@ const outline = { lookId: "look", root, nodes: [root, ...root.children], refToWi
 const ranked = searchOutlineRanked(outline, "save", "button", "press", 12);
 assert.deepEqual(ranked.matches.map((match) => match.matchReason), ["exact", "prefix", "substring", "fuzzy"]);
 assert.equal(ranked.totalMatches, 4);
+const serializedMatch = serializeOutlineSearchMatch(ranked.matches[0]);
+assert.equal("node" in serializedMatch, false, "agent-facing matches must not expose cyclic outline nodes");
+assert.doesNotThrow(
+	() => JSON.stringify({ tool: "wait_for", target: serializedMatch }),
+	"successful wait_for details must be session-serializable",
+);
 clearStoredOutputs();
 
 console.log("Bounded output and ranked search checks passed.");

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -10,7 +10,7 @@ import { canRetryInForeground, outcomeAfterCheck, outcomeAfterObservedValues, pr
 import { cdpClickForContext, cdpDragForContext, cdpEvaluateForContext, cdpKeypressForContext, cdpMouseForContext, cdpNavigateContext, cdpScrollForContext, cdpSnapshotForContext, cdpTabForWindow, cdpTypeFocusedForContext, cdpTypeForContext, disconnectCdp, listCdpPageContexts, type CdpConsoleEntry, type CdpPageSnapshot } from "./cdp.ts";
 import { getComputerUseConfig, isBrowserUseEnabled, isHeadlessMode, loadComputerUseConfig } from "./config.ts";
 import { noteAfterAct, noteFromLook, noteRegionKeyForRef, renderNote, type WindowNote } from "./note.ts";
-import { foldToBudget, graftScopedOutline, nodeByRef, outlineNodeLabel, outlineNodePath, rankedTextMatch, restoreOutline, searchOutline, searchOutlineRanked, serializeOutline, serializeOutlineNodeShallow, type LookResponse, type Outline, type OutlineChange, type OutlineNode, type OutlineSearchMatch, type SerializedOutline, type SerializedOutlineNode } from "./outline.ts";
+import { foldToBudget, graftScopedOutline, nodeByRef, outlineNodeLabel, outlineNodePath, rankedTextMatch, restoreOutline, searchOutline, searchOutlineRanked, serializeOutline, serializeOutlineNodeShallow, serializeOutlineSearchMatch, type LookResponse, type Outline, type OutlineChange, type OutlineNode, type OutlineSearchMatch, type SerializedOutline, type SerializedOutlineNode, type SerializedOutlineSearchMatch } from "./outline.ts";
 import { applyOutputEnvelope, boundToolError, clearStoredOutputs, OUTPUT_PAGE_BYTES, readStoredOutput, UI_TEXT_PAGE_CHARS } from "./output.ts";
 import { AGENT_TOOL_NAMES, type ActParams, type EvaluateBrowserParams, type ExpandUiParams, type ImageMode, type InspectUiParams, type LaunchBrowserParams, type FindParams, type MouseButtonName, type NavigateBrowserParams, type ObserveParams, type ObserveTargetParams, type ReadTextParams, type RootSelector, type SearchUiParams, type StateTargetParams, type UiAction, type WaitForParams } from "./contract.ts";
 import { toFiniteNumber } from "./platform/coerce.ts";
@@ -200,7 +200,7 @@ interface WaitForDetails {
 	found: boolean;
 	gone?: boolean;
 	timedOut?: boolean;
-	target?: OutlineSearchMatch;
+	target?: SerializedOutlineSearchMatch;
 	nodeCount?: number;
 	text?: string;
 	role?: string;
@@ -219,7 +219,7 @@ interface OutlineToolDetails {
 	totalMatches?: number;
 	returned?: number;
 	hasMore?: boolean;
-	matches?: Array<Omit<OutlineSearchMatch, "node"> & { node?: SerializedOutlineNode }>;
+	matches?: SerializedOutlineSearchMatch[];
 	target?: SerializedOutlineNode;
 	note?: WindowNote;
 }
@@ -1622,7 +1622,7 @@ async function performWaitFor(params: WaitForParams, signal?: AbortSignal): Prom
 		found: raw.found,
 		gone: raw.gone || undefined,
 		timedOut: raw.timedOut || undefined,
-		target: foundTarget,
+		target: foundTarget ? serializeOutlineSearchMatch(foundTarget) : undefined,
 		nodeCount: Number.isFinite(raw.nodeCount) ? Number(raw.nodeCount) : refreshed.outline.nodes.length,
 		text,
 		role,
@@ -1729,7 +1729,7 @@ async function performSearchUi(params: SearchUiParams, signal?: AbortSignal): Pr
 		matches = ranked.matches;
 		escalatedOCR = true;
 	}
-	const detailMatches = matches.map(({ node: _node, ...match }) => match);
+	const detailMatches = matches.map(serializeOutlineSearchMatch);
 	const details: OutlineToolDetails = { tool: "search_ui", stateId: state.currentCapture?.stateId, lookId: outline.lookId, matches: detailMatches, totalMatches: ranked.totalMatches, returned: matches.length, hasMore: ranked.totalMatches > matches.length, note: state.currentNote };
 	const lines = matches.map((match) => `${match.ref} ${match.role || "Unknown"} ${JSON.stringify(match.label || "(unlabeled)")} [${match.matchReason}${match.matchReason === "fuzzy" ? ` ${match.score?.toFixed(2)}` : ""}]\n  path: ${match.path}`);
 	const noteHeader = renderNote(state.currentNote);

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -93,6 +93,8 @@ export interface OutlineSearchMatch {
 	node: OutlineNode;
 }
 
+export type SerializedOutlineSearchMatch = Omit<OutlineSearchMatch, "node">;
+
 export interface FoldResult {
 	text: string;
 	renderedRefs: string[];
@@ -488,6 +490,11 @@ export function searchOutline(outline: Outline, text?: string, role?: string, ac
 		if (matches.length >= limit) break;
 	}
 	return matches;
+}
+
+export function serializeOutlineSearchMatch(match: OutlineSearchMatch): SerializedOutlineSearchMatch {
+	const { node: _node, ...serialized } = match;
+	return serialized;
 }
 
 export function countOutlineNodes(root: OutlineNode): number {


### PR DESCRIPTION
closes #37

## root cause

desktop `wait_for` returned an internal `OutlineSearchMatch` in tool details. its `node` retains bidirectional parent/children links, so pi session persistence failed when serializing a successful matching result.

## change

- define a json-safe serialized search-match dto that omits the internal node
- use it for `wait_for` and `search_ui` details
- cover successful wait-detail serialization with a regression check

## validation

- `npm test`