### PR TITLE
test(core): enforce serialized match boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 node_modules/
 index-*.js
 main.js
+*.tsbuildinfo
+docs/.next/
+docs/.source/
 
 # Local benchmark output
 benchmarks/results/*.local.*

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -93,7 +93,7 @@ export interface OutlineSearchMatch {
 	node: OutlineNode;
 }
 
-export type SerializedOutlineSearchMatch = Omit<OutlineSearchMatch, "node">;
+export type SerializedOutlineSearchMatch = Omit<OutlineSearchMatch, "node"> & { node?: never };
 
 export interface FoldResult {
 	text: string;


### PR DESCRIPTION
## change

- reject internal outline nodes at serialized match boundaries at compile time
- ignore generated documentation build artifacts

## validation

- npm test
- git diff --check