### PR TITLE
fix(macos): bound broad root discovery

### DIFF
--- a/native/macos/bridge.swift
+++ b/native/macos/bridge.swift
@@ -421,6 +421,7 @@ final class Bridge {
 	}
 
 	private func runServer(socketPath: String) {
+		_ = signal(SIGPIPE, SIG_IGN)
 		try? FileManager.default.createDirectory(atPath: (socketPath as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
 		// LaunchServices may race multiple `open -n` requests while the first
 		// daemon is still binding. Keep process ownership separate from socket
@@ -450,25 +451,27 @@ final class Bridge {
 		while true {
 			let client = accept(server, nil, nil)
 			if client < 0 { continue }
+			var noSigPipe: Int32 = 1
+			_ = setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout.size(ofValue: noSigPipe)))
 			Thread.detachNewThread { [weak self] in self?.processClient(client) }
 		}
 	}
 
 	private func processClient(_ client: Int32) {
-		let clientOutput = FileHandle(fileDescriptor: client, closeOnDealloc: true)
+		let clientInput = FileHandle(fileDescriptor: client, closeOnDealloc: true)
 		var buffer = Data()
 		let newline = Data([0x0A])
 		while true {
-			let data = clientOutput.availableData
+			let data = clientInput.availableData
 			if data.isEmpty { break }
 			buffer.append(data)
 			while let range = buffer.range(of: newline) {
 				let lineData = buffer.subdata(in: 0..<range.lowerBound)
 				buffer.removeSubrange(0..<range.upperBound)
-				if let line = String(data: lineData, encoding: .utf8), !line.isEmpty { handleLine(line, to: clientOutput) }
+				if let line = String(data: lineData, encoding: .utf8), !line.isEmpty { handleLine(line, to: client) }
 			}
 		}
-		clientOutput.closeFile()
+		clientInput.closeFile()
 	}
 
 	private func processBufferedInput() {
@@ -483,7 +486,7 @@ final class Bridge {
 		}
 	}
 
-	private func handleLine(_ line: String, to responseOutput: FileHandle? = nil) {
+	private func handleLine(_ line: String, to responseSocket: Int32? = nil) {
 		let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
 		guard !trimmed.isEmpty else { return }
 
@@ -503,7 +506,7 @@ final class Bridge {
 					"id": id,
 					"ok": true,
 					"result": result,
-				], to: responseOutput)
+				], to: responseSocket)
 			} catch let failure as BridgeFailure {
 				send([
 					"id": id,
@@ -512,7 +515,7 @@ final class Bridge {
 						"message": failure.message,
 						"code": failure.code,
 					],
-				], to: responseOutput)
+				], to: responseSocket)
 			} catch {
 				send([
 					"id": id,
@@ -521,7 +524,7 @@ final class Bridge {
 						"message": error.localizedDescription,
 						"code": "internal_error",
 					],
-				], to: responseOutput)
+				], to: responseSocket)
 			}
 		} catch let failure as BridgeFailure {
 			send([
@@ -531,7 +534,7 @@ final class Bridge {
 					"message": failure.message,
 					"code": failure.code,
 				],
-			], to: responseOutput)
+			], to: responseSocket)
 		} catch {
 			send([
 				"id": fallbackId,
@@ -540,20 +543,31 @@ final class Bridge {
 					"message": error.localizedDescription,
 					"code": "internal_error",
 				],
-			], to: responseOutput)
+			], to: responseSocket)
 		}
 	}
 
-	private func send(_ payload: [String: Any], to responseOutput: FileHandle? = nil) {
+	private func send(_ payload: [String: Any], to responseSocket: Int32? = nil) {
 		guard JSONSerialization.isValidJSONObject(payload),
 			let data = try? JSONSerialization.data(withJSONObject: payload),
-			let line = String(data: data, encoding: .utf8)
+			let line = String(data: data, encoding: .utf8),
+			let out = (line + "\n").data(using: .utf8)
 		else {
 			return
 		}
 
-		if let out = (line + "\n").data(using: .utf8) {
-			(responseOutput ?? output).write(out)
+		guard let responseSocket else {
+			try? output.write(contentsOf: out)
+			return
+		}
+		out.withUnsafeBytes { raw in
+			guard let base = raw.baseAddress else { return }
+			var offset = 0
+			while offset < raw.count {
+				let sent = Darwin.send(responseSocket, base.advanced(by: offset), raw.count - offset, 0)
+				if sent <= 0 { return }
+				offset += sent
+			}
 		}
 	}
 
@@ -903,7 +917,7 @@ final class Bridge {
 		// even when their windows are visible and AX-controllable. Add CGWindow
 		// owners as acquisition candidates so callers can still resolve by pid/title
 		// and then build the normal AX scene through listWindows(pid:).
-		for owner in cgWindowOwners() where owner.pid != getpid() && !seen.contains(owner.pid) && pidIsAlive(owner.pid) {
+		for owner in cgWindowOwners() + cgPopupMenuOwners() where owner.pid != getpid() && !seen.contains(owner.pid) && pidIsAlive(owner.pid) {
 			seen.insert(owner.pid)
 			output.append([
 				"appName": owner.name,
@@ -1111,25 +1125,40 @@ final class Bridge {
 		["pairing": ["confidence": pairing.confidence, "score": pairing.score], "sheetCount": sheetCount]
 	}
 
-	private func listRoots(pid: Int32?, title: String? = nil) throws -> [String: Any] {
-		let requestedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
-		let apps: [[String: Any]]
+	private func rootCandidateApps(pid: Int32?, title: String?) -> [[String: Any]] {
+		let apps = listApps()
 		if let pid {
-			apps = [["pid": Int(pid)]]
-		} else if !requestedTitle.isEmpty,
+			return apps.first(where: { ($0["pid"] as? Int) == Int(pid) }).map { [$0] }
+				?? [["pid": Int(pid)]]
+		}
+
+		let requestedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+		if !requestedTitle.isEmpty,
 			let entries = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] {
 			let matchingPids = Set(entries.compactMap { entry -> Int32? in
 				let candidate = ((entry[kCGWindowName as String] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 				guard candidate == requestedTitle || candidate.contains(requestedTitle) else { return nil }
 				return (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
 			})
-			apps = listApps().filter { app in
+			return apps.filter { app in
 				guard let rawPid = app["pid"] as? Int else { return false }
 				return matchingPids.contains(Int32(rawPid))
 			}
-		} else {
-			apps = listApps()
 		}
+
+		// Root discovery should cross AX only for processes that can own a
+		// controllable top-level surface. listApps intentionally remains broad for
+		// app resolution, while this preflight excludes WebKit/XPC children that
+		// cannot contribute roots and may not answer AX requests.
+		let ownerPids = Set((cgWindowOwners() + cgPopupMenuOwners()).map(\.pid))
+		return apps.filter { app in
+			guard let rawPid = app["pid"] as? Int else { return false }
+			return ownerPids.contains(Int32(rawPid))
+		}
+	}
+
+	private func listRoots(pid: Int32?, title: String? = nil) throws -> [String: Any] {
+		let apps = rootCandidateApps(pid: pid, title: title)
 		var roots: [[String: Any]] = []
 		for app in apps {
 			guard let rawPid = app["pid"] as? Int else { continue }
@@ -1142,9 +1171,13 @@ final class Bridge {
 				if let bundleId { root["bundleId"] = bundleId }
 				roots.append(root)
 			}
-			let menuElements = openMenuElements(pid: appPid)
-			for (index, candidate) in cgPopupMenuCandidates(pid: appPid).enumerated() {
-				let menuElement = index < menuElements.count ? menuElements[index] : nil
+			let popupCandidates = cgPopupMenuCandidates(pid: appPid)
+			let menuElements = popupCandidates.isEmpty ? [] : openMenuElements(pid: appPid)
+			let menuPairings = windowPairings(windows: menuElements, candidates: popupCandidates)
+			for candidate in popupCandidates {
+				let menuElement = menuElements.first {
+					menuPairings[ObjectIdentifier($0)]?.candidate?.windowId == candidate.windowId
+				}
 				let menuRef = menuElement.map { refStore.storeWindow($0) } ?? "cgmenu:\(candidate.windowId)"
 				var menu: [String: Any] = [
 					"kind": "menu",
@@ -2898,6 +2931,23 @@ final class Bridge {
 			)
 		}
 		return candidates
+	}
+
+	private func cgPopupMenuOwners() -> [CGWindowOwnerSummary] {
+		guard let entries = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] else {
+			return []
+		}
+		let popupLevel = Int(CGWindowLevelForKey(.popUpMenuWindow))
+		var seen = Set<Int32>()
+		return entries.compactMap { entry -> CGWindowOwnerSummary? in
+			let layer = (entry[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+			guard layer == popupLevel,
+				let pid = (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+				seen.insert(pid).inserted
+			else { return nil }
+			let name = (entry[kCGWindowOwnerName as String] as? String) ?? processName(pid: pid) ?? "Unknown App"
+			return CGWindowOwnerSummary(pid: pid, name: name)
+		}
 	}
 
 	private func cgPopupMenuCandidates(pid: Int32?) -> [CGWindowCandidate] {

--- a/native/macos/bridge.swift
+++ b/native/macos/bridge.swift
@@ -390,6 +390,8 @@ final class Bridge {
 	private let maxRootObservers = 4
 	private let permissionCacheLock = NSLock()
 	private var grantedPermissionStatus: [String: Any]?
+	private let completedRequestLock = NSLock()
+	private var recentCompletedRequestIds: [String] = []
 
 	func run() {
 		if CommandLine.arguments.contains("serve") {
@@ -491,6 +493,10 @@ final class Bridge {
 		guard !trimmed.isEmpty else { return }
 
 		let fallbackId = "invalid"
+		var completionId: String?
+		defer {
+			if responseSocket != nil, let completionId { recordCompletedRequest(completionId) }
+		}
 		do {
 			guard let jsonData = trimmed.data(using: .utf8) else {
 				throw BridgeFailure(message: "Input was not valid UTF-8", code: "invalid_request")
@@ -499,6 +505,7 @@ final class Bridge {
 				throw BridgeFailure(message: "Request must be a JSON object", code: "invalid_request")
 			}
 			let id = (object["id"] as? String) ?? fallbackId
+			completionId = id
 
 			do {
 				let result = try handleRequest(object)
@@ -569,6 +576,22 @@ final class Bridge {
 				offset += sent
 			}
 		}
+	}
+
+	private func recordCompletedRequest(_ id: String) {
+		completedRequestLock.lock()
+		recentCompletedRequestIds.removeAll { $0 == id }
+		recentCompletedRequestIds.append(id)
+		if recentCompletedRequestIds.count > 32 {
+			recentCompletedRequestIds.removeFirst(recentCompletedRequestIds.count - 32)
+		}
+		completedRequestLock.unlock()
+	}
+
+	private func completedRequestIds() -> [String] {
+		completedRequestLock.lock()
+		defer { completedRequestLock.unlock() }
+		return recentCompletedRequestIds
 	}
 
 	private func handleRequest(_ request: [String: Any]) throws -> Any {
@@ -735,6 +758,7 @@ final class Bridge {
 			"arch": arch,
 			"accessibility": permissions["accessibility"] ?? false,
 			"screenRecording": permissions["screenRecording"] ?? false,
+			"recentCompletedRequestIds": completedRequestIds(),
 		]
 		if let parentPath {
 			output["parentPath"] = parentPath
@@ -917,7 +941,7 @@ final class Bridge {
 		// even when their windows are visible and AX-controllable. Add CGWindow
 		// owners as acquisition candidates so callers can still resolve by pid/title
 		// and then build the normal AX scene through listWindows(pid:).
-		for owner in cgWindowOwners() + cgPopupMenuOwners() where owner.pid != getpid() && !seen.contains(owner.pid) && pidIsAlive(owner.pid) {
+		for owner in cgWindowOwners() where owner.pid != getpid() && !seen.contains(owner.pid) && pidIsAlive(owner.pid) {
 			seen.insert(owner.pid)
 			output.append([
 				"appName": owner.name,
@@ -1125,40 +1149,36 @@ final class Bridge {
 		["pairing": ["confidence": pairing.confidence, "score": pairing.score], "sheetCount": sheetCount]
 	}
 
-	private func rootCandidateApps(pid: Int32?, title: String?) -> [[String: Any]] {
-		let apps = listApps()
-		if let pid {
-			return apps.first(where: { ($0["pid"] as? Int) == Int(pid) }).map { [$0] }
-				?? [["pid": Int(pid)]]
+	private func broadRootCandidateApps() -> [[String: Any]] {
+		cgBroadRootOwners().compactMap { owner in
+			guard owner.pid != getpid(), pidIsAlive(owner.pid) else { return nil }
+			var app: [String: Any] = ["appName": owner.name, "pid": Int(owner.pid)]
+			if let bundleId = NSRunningApplication(processIdentifier: owner.pid)?.bundleIdentifier {
+				app["bundleId"] = bundleId
+			}
+			return app
 		}
+	}
 
+	private func listRoots(pid: Int32?, title: String? = nil) throws -> [String: Any] {
 		let requestedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
-		if !requestedTitle.isEmpty,
+		let apps: [[String: Any]]
+		if let pid {
+			apps = [["pid": Int(pid)]]
+		} else if !requestedTitle.isEmpty,
 			let entries = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] {
 			let matchingPids = Set(entries.compactMap { entry -> Int32? in
 				let candidate = ((entry[kCGWindowName as String] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 				guard candidate == requestedTitle || candidate.contains(requestedTitle) else { return nil }
 				return (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
 			})
-			return apps.filter { app in
+			apps = listApps().filter { app in
 				guard let rawPid = app["pid"] as? Int else { return false }
 				return matchingPids.contains(Int32(rawPid))
 			}
+		} else {
+			apps = broadRootCandidateApps()
 		}
-
-		// Root discovery should cross AX only for processes that can own a
-		// controllable top-level surface. listApps intentionally remains broad for
-		// app resolution, while this preflight excludes WebKit/XPC children that
-		// cannot contribute roots and may not answer AX requests.
-		let ownerPids = Set((cgWindowOwners() + cgPopupMenuOwners()).map(\.pid))
-		return apps.filter { app in
-			guard let rawPid = app["pid"] as? Int else { return false }
-			return ownerPids.contains(Int32(rawPid))
-		}
-	}
-
-	private func listRoots(pid: Int32?, title: String? = nil) throws -> [String: Any] {
-		let apps = rootCandidateApps(pid: pid, title: title)
 		var roots: [[String: Any]] = []
 		for app in apps {
 			guard let rawPid = app["pid"] as? Int else { continue }
@@ -1173,11 +1193,8 @@ final class Bridge {
 			}
 			let popupCandidates = cgPopupMenuCandidates(pid: appPid)
 			let menuElements = popupCandidates.isEmpty ? [] : openMenuElements(pid: appPid)
-			let menuPairings = windowPairings(windows: menuElements, candidates: popupCandidates)
-			for candidate in popupCandidates {
-				let menuElement = menuElements.first {
-					menuPairings[ObjectIdentifier($0)]?.candidate?.windowId == candidate.windowId
-				}
+			for (index, candidate) in popupCandidates.enumerated() {
+				let menuElement = index < menuElements.count ? menuElements[index] : nil
 				let menuRef = menuElement.map { refStore.storeWindow($0) } ?? "cgmenu:\(candidate.windowId)"
 				var menu: [String: Any] = [
 					"kind": "menu",
@@ -2933,7 +2950,7 @@ final class Bridge {
 		return candidates
 	}
 
-	private func cgPopupMenuOwners() -> [CGWindowOwnerSummary] {
+	private func cgBroadRootOwners() -> [CGWindowOwnerSummary] {
 		guard let entries = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] else {
 			return []
 		}
@@ -2941,7 +2958,7 @@ final class Bridge {
 		var seen = Set<Int32>()
 		return entries.compactMap { entry -> CGWindowOwnerSummary? in
 			let layer = (entry[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
-			guard layer == popupLevel,
+			guard layer == 0 || layer == popupLevel,
 				let pid = (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
 				seen.insert(pid).inserted
 			else { return nil }

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -225,17 +225,21 @@ check("INV-19 macOS root identity resolution", () => {
 });
 
 check("INV-20 bounded broad root discovery", () => {
-	assert(swift.includes("private func rootCandidateApps"), "macOS helper lacks a root-candidate preflight");
-	assert(swift.includes("Set((cgWindowOwners() + cgPopupMenuOwners()).map(\\.pid))"), "broad root discovery is not bounded by top-level and popup-menu owners");
-	assert(swift.includes("for owner in cgWindowOwners() + cgPopupMenuOwners()"), "listApps omits menu-only accessory owners");
+	assert(swift.includes("private func broadRootCandidateApps"), "macOS helper lacks a broad root-candidate preflight");
+	assert(swift.includes("private func cgBroadRootOwners"), "macOS helper lacks a dedicated broad-owner preflight");
+	assert(swift.includes("layer == 0 || layer == popupLevel"), "broad root discovery is not bounded by layer-0 and popup-menu owners");
+	assert(swift.includes("bounds.width >= 100") && swift.includes("bounds.height >= 80"), "listApps no longer retains its established owner threshold");
+	assert(!swift.includes("for owner in cgWindowOwners() + cgPopupMenuOwners()"), "listApps includes unrelated popup-owner expansion");
+	assert(swift.includes("if let pid {\n\t\t\tapps = [[\"pid\": Int(pid)]]"), "explicit-pid root discovery no longer stays immediate");
 	assert(swift.includes("popupCandidates.isEmpty ? [] : openMenuElements"), "root discovery traverses menus when no popup exists");
-	assert(swift.includes("let menuPairings = windowPairings(windows: menuElements, candidates: popupCandidates)"), "popup roots are paired by traversal order instead of geometry and identity evidence");
-	assert(ts.includes("async function rootsForFind"), "find_roots lacks a root-acquisition module");
-	assert(/if \(!query\.app && !query\.bundleId\)[\s\S]{0,160}listRoots\(\{\}, signal\)/.test(ts), "broad find_roots does not use one platform listRoots call");
-	assert(!ts.includes("collectWindowDetails(await listApps(signal)"), "broad root discovery still uses listApps as its acquisition seam");
+	assert(!swift.includes("let menuPairings = windowPairings(windows: menuElements, candidates: popupCandidates)"), "root discovery includes unrelated menu-pairing changes");
+	assert(ts.includes("async function windowDetailsForFind"), "find_roots lacks an explicit root-acquisition boundary");
+	assert(/if \(!query\.app && !query\.bundleId && !Number\.isFinite\(query\.pid\)\)[\s\S]{0,160}listRoots\(\{\}, signal\)/.test(ts), "broad find_roots does not use one platform listRoots call");
+	assert(ts.includes("return await collectWindowDetails(apps, config, signal)"), "filtered find_roots does not retain per-app discovery");
 	assert(swift.includes("signal(SIGPIPE, SIG_IGN)"), "helper daemon does not ignore process-wide SIGPIPE");
 	assert(swift.includes("SO_NOSIGPIPE"), "helper sockets can terminate the daemon on a late response");
 	assert(swift.includes("Darwin.send(responseSocket"), "helper socket responses do not use failure-tolerant writes");
+	assert(swift.includes("recentCompletedRequestIds"), "helper diagnostics cannot establish abandoned-request completion");
 });
 
 check("INV-8 swift typecheck", () => {
@@ -293,6 +297,16 @@ function abandon(socketPath, payload) {
 		});
 		socket.on("error", reject);
 	});
+}
+
+async function waitForCompletedRequest(socketPath, requestId, timeoutMs = 10000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const diagnostics = await call(socketPath, { id: `inv-completion-${Date.now()}`, cmd: "diagnostics" });
+		if (diagnostics.recentCompletedRequestIds?.includes(requestId)) return diagnostics;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	throw new Error(`request ${requestId} did not complete within ${timeoutMs}ms`);
 }
 
 function callEnvelope(socketPath, payload, timeoutMs = 10000) {
@@ -358,9 +372,9 @@ async function liveChecks() {
 			assert(broadDiscoveryMs < 10000, `broad listRoots took ${broadDiscoveryMs}ms`);
 			assert(diagnosticsAfterBroadDiscovery.protocolVersion === 6, "helper did not survive broad listRoots");
 		});
-		await abandon(socketPath, { id: "inv-abandoned-roots", cmd: "listRoots" });
-		await new Promise((resolve) => setTimeout(resolve, Math.min(5000, Math.max(1000, broadDiscoveryMs * 2))));
-		const diagnosticsAfterAbandon = await call(socketPath, { id: "inv-diagnostics-after-abandon", cmd: "diagnostics" });
+		const abandonedRequestId = `inv-abandoned-roots-${process.pid}-${Date.now()}`;
+		await abandon(socketPath, { id: abandonedRequestId, cmd: "listRoots" });
+		const diagnosticsAfterAbandon = await waitForCompletedRequest(socketPath, abandonedRequestId);
 		check("LIVE abandoned root discovery keeps helper alive", () => {
 			assert(diagnosticsAfterAbandon.protocolVersion === 6, "helper died after writing to an abandoned root-discovery socket");
 		});

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -224,6 +224,20 @@ check("INV-19 macOS root identity resolution", () => {
 	assert(swift.includes("($0[kCGWindowNumber as String] as? NSNumber)?.uint32Value == windowId"), "window lookup does not verify the returned stable ID");
 });
 
+check("INV-20 bounded broad root discovery", () => {
+	assert(swift.includes("private func rootCandidateApps"), "macOS helper lacks a root-candidate preflight");
+	assert(swift.includes("Set((cgWindowOwners() + cgPopupMenuOwners()).map(\\.pid))"), "broad root discovery is not bounded by top-level and popup-menu owners");
+	assert(swift.includes("for owner in cgWindowOwners() + cgPopupMenuOwners()"), "listApps omits menu-only accessory owners");
+	assert(swift.includes("popupCandidates.isEmpty ? [] : openMenuElements"), "root discovery traverses menus when no popup exists");
+	assert(swift.includes("let menuPairings = windowPairings(windows: menuElements, candidates: popupCandidates)"), "popup roots are paired by traversal order instead of geometry and identity evidence");
+	assert(ts.includes("async function rootsForFind"), "find_roots lacks a root-acquisition module");
+	assert(/if \(!query\.app && !query\.bundleId\)[\s\S]{0,160}listRoots\(\{\}, signal\)/.test(ts), "broad find_roots does not use one platform listRoots call");
+	assert(!ts.includes("collectWindowDetails(await listApps(signal)"), "broad root discovery still uses listApps as its acquisition seam");
+	assert(swift.includes("signal(SIGPIPE, SIG_IGN)"), "helper daemon does not ignore process-wide SIGPIPE");
+	assert(swift.includes("SO_NOSIGPIPE"), "helper sockets can terminate the daemon on a late response");
+	assert(swift.includes("Darwin.send(responseSocket"), "helper socket responses do not use failure-tolerant writes");
+});
+
 check("INV-8 swift typecheck", () => {
 	const triple = process.arch === "x64" ? "x86_64-apple-macosx14.0" : "arm64-apple-macosx14.0";
 	execFileSync("xcrun", [
@@ -265,6 +279,19 @@ function call(socketPath, payload, timeoutMs = 10000) {
 			clearTimeout(timer);
 			reject(error);
 		});
+	});
+}
+
+function abandon(socketPath, payload) {
+	return new Promise((resolve, reject) => {
+		const socket = net.createConnection(socketPath);
+		socket.on("connect", () => {
+			socket.write(`${JSON.stringify(payload)}\n`, () => {
+				socket.destroy();
+				resolve();
+			});
+		});
+		socket.on("error", reject);
 	});
 }
 
@@ -322,6 +349,21 @@ async function liveChecks() {
 		const socketPath = process.env.PI_CU_SOCKET_PATH ?? path.join(os.homedir(), "Library/Caches/pi-computer-use/bridge.sock");
 		const diagnostics = await call(socketPath, { id: "inv-diagnostics", cmd: "diagnostics" });
 		check("LIVE diagnostics current protocol", () => assert(diagnostics.protocolVersion === 6, `protocolVersion=${diagnostics.protocolVersion}`));
+		const broadDiscoveryStarted = Date.now();
+		const broadRoots = await call(socketPath, { id: "inv-broad-roots", cmd: "listRoots" }, 10000);
+		const broadDiscoveryMs = Date.now() - broadDiscoveryStarted;
+		const diagnosticsAfterBroadDiscovery = await call(socketPath, { id: "inv-diagnostics-after-broad-roots", cmd: "diagnostics" });
+		check("LIVE broad root discovery is bounded and keeps helper alive", () => {
+			assert(Array.isArray(broadRoots?.roots), "broad listRoots did not return roots");
+			assert(broadDiscoveryMs < 10000, `broad listRoots took ${broadDiscoveryMs}ms`);
+			assert(diagnosticsAfterBroadDiscovery.protocolVersion === 6, "helper did not survive broad listRoots");
+		});
+		await abandon(socketPath, { id: "inv-abandoned-roots", cmd: "listRoots" });
+		await new Promise((resolve) => setTimeout(resolve, Math.min(5000, Math.max(1000, broadDiscoveryMs * 2))));
+		const diagnosticsAfterAbandon = await call(socketPath, { id: "inv-diagnostics-after-abandon", cmd: "diagnostics" });
+		check("LIVE abandoned root discovery keeps helper alive", () => {
+			assert(diagnosticsAfterAbandon.protocolVersion === 6, "helper died after writing to an abandoned root-discovery socket");
+		});
 		const explicitWindowId = process.env.PI_CU_LIVE_WINDOW_ID ? Number(process.env.PI_CU_LIVE_WINDOW_ID) : undefined;
 		let windows = [];
 		try {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -839,28 +839,27 @@ async function resolveTargetByWindowSelector(selector: RootSelector, signal?: Ab
 	}
 
 	const numericWindowId = Number(normalized);
+	if (Number.isInteger(numericWindowId) && numericWindowId > 0) {
+		const apps = await listApps(signal);
+		for (const app of apps) {
+			const windows = await listWindows(app.pid, signal);
+			const match = windows.find((window) => window.windowId === numericWindowId);
+			if (match) {
+				assertBrowserUseAllowed(app);
+				const resolved = toResolvedTarget(app, match);
+				setCurrentTarget(resolved);
+				return resolved;
+			}
+		}
+		throw new Error(`Window id '${numericWindowId}' was not found. Call find_roots again and choose a current window.`);
+	}
+
 	if (normalized.startsWith("@r")) {
 		throw new Error(`Root ref '${normalized}' is not available in this session. Call find_roots first.`);
 	}
 
 	const config = getComputerUseConfig();
-	const candidates = collectWindowDetails(await currentPlatformBackend.listRoots({}, signal), config);
-	if (Number.isInteger(numericWindowId) && numericWindowId > 0) {
-		const match = candidates.find((candidate) => candidate.windowId === numericWindowId);
-		if (!match) {
-			throw new Error(`Window id '${numericWindowId}' was not found. Call find_roots again and choose a current window.`);
-		}
-		const app: HelperApp = { appName: match.app, bundleId: match.bundleId, pid: match.pid };
-		assertBrowserUseAllowed(app);
-		const roots = await listWindows(match.pid, signal);
-		const helperRoot = roots.find((root) => root.windowId === numericWindowId) ?? roots[0];
-		if (!helperRoot) {
-			throw new Error(`Window id '${numericWindowId}' disappeared during resolution. Call find_roots again.`);
-		}
-		const resolved = toResolvedTarget(app, helperRoot);
-		setCurrentTarget(resolved);
-		return resolved;
-	}
+	const candidates = await collectWindowDetails(await listApps(signal), config, signal);
 	const query = normalizeText(normalized);
 	const exact = candidates.filter((candidate) => normalizeText(candidate.app) === query || normalizeText(candidate.windowTitle) === query);
 	const fuzzy = exact.length > 0 ? exact : candidates.filter((candidate) => `${normalizeText(candidate.app)} ${normalizeText(candidate.windowTitle)}`.includes(query));
@@ -1294,63 +1293,59 @@ function rootDeltaLines(execution: ExecutionTrace): string[] {
 	});
 }
 
+function windowDetails(app: HelperApp, window: HelperWindow, config: ReturnType<typeof getComputerUseConfig>): ListWindowsDetails["windows"][number] {
+	const storedRef = storeWindowRefForAppWindow(app, window);
+	return {
+		app: app.appName,
+		bundleId: app.bundleId,
+		pid: app.pid,
+		kind: window.kind,
+		windowTitle: window.title || "(untitled)",
+		windowId: window.windowId,
+		windowRef: storedRef.ref,
+		nativeWindowRef: window.windowRef,
+		framePoints: window.framePoints,
+		scaleFactor: window.scaleFactor,
+		isMinimized: window.isMinimized,
+		isOnscreen: window.isOnscreen,
+		isMain: window.isMain,
+		isFocused: window.isFocused,
+		isModal: window.isModal,
+		sheetCount: platformRootSheetCount(window),
+		role: window.role,
+		subrole: window.subrole,
+		pairing: platformRootPairing(window),
+		zOrder: window.zOrder,
+		browserUseAllowed: config.browser_use || !currentPlatformBackend.isBrowserApp(app.appName, app.bundleId),
+		score: scoreWindow(window),
+	};
+}
+
+function sortWindowDetails(windows: ListWindowsDetails["windows"]): ListWindowsDetails["windows"] {
+	return windows.sort((a, b) => b.score - a.score || a.app.localeCompare(b.app) || a.windowTitle.localeCompare(b.windowTitle));
+}
+
 // Side effect: stores stable @r refs for discovered windows in runtimeState.
-function collectWindowDetails(roots: HelperWindow[], config: ReturnType<typeof getComputerUseConfig>): ListWindowsDetails["windows"] {
+async function collectWindowDetails(apps: HelperApp[], config: ReturnType<typeof getComputerUseConfig>, signal?: AbortSignal): Promise<ListWindowsDetails["windows"]> {
+	const perApp = await Promise.all(apps.map(async (app) => ({ app, windows: await listWindows(app.pid, signal) })));
+	return sortWindowDetails(perApp.flatMap(({ app, windows }) => windows.map((window) => windowDetails(app, window, config))));
+}
+
+function collectBroadWindowDetails(roots: HelperWindow[], config: ReturnType<typeof getComputerUseConfig>): ListWindowsDetails["windows"] {
 	const windows: ListWindowsDetails["windows"] = [];
 	for (const window of roots) {
 		if (!window.pid) continue;
-		const app: HelperApp = {
-			appName: window.appName ?? "Unknown App",
-			bundleId: window.bundleId,
-			pid: window.pid,
-		};
-		const storedRef = storeWindowRefForAppWindow(app, window);
-		windows.push({
-			app: app.appName,
-			bundleId: app.bundleId,
-			pid: app.pid,
-			kind: window.kind,
-			windowTitle: window.title || "(untitled)",
-			windowId: window.windowId,
-			windowRef: storedRef.ref,
-			nativeWindowRef: window.windowRef,
-			framePoints: window.framePoints,
-			scaleFactor: window.scaleFactor,
-			isMinimized: window.isMinimized,
-			isOnscreen: window.isOnscreen,
-			isMain: window.isMain,
-			isFocused: window.isFocused,
-			isModal: window.isModal,
-			sheetCount: platformRootSheetCount(window),
-			role: window.role,
-			subrole: window.subrole,
-			pairing: platformRootPairing(window),
-			zOrder: window.zOrder,
-			browserUseAllowed: config.browser_use || !currentPlatformBackend.isBrowserApp(app.appName, app.bundleId),
-			score: scoreWindow(window),
-		});
+		windows.push(windowDetails({ appName: window.appName ?? "Unknown App", bundleId: window.bundleId, pid: window.pid }, window, config));
 	}
-	windows.sort((a, b) => b.score - a.score || a.app.localeCompare(b.app) || a.windowTitle.localeCompare(b.windowTitle));
-	return windows;
+	return sortWindowDetails(windows);
 }
 
-async function rootsForFind(query: FindParams, signal?: AbortSignal): Promise<HelperWindow[]> {
-	if (Number.isFinite(query.pid)) {
-		return await currentPlatformBackend.listRoots({ pid: query.pid }, signal);
+async function windowDetailsForFind(query: FindParams, config: ReturnType<typeof getComputerUseConfig>, signal?: AbortSignal): Promise<ListWindowsDetails["windows"]> {
+	if (!query.app && !query.bundleId && !Number.isFinite(query.pid)) {
+		return collectBroadWindowDetails(await currentPlatformBackend.listRoots({}, signal), config);
 	}
-	if (!query.app && !query.bundleId) {
-		return await currentPlatformBackend.listRoots({}, signal);
-	}
-
-	let apps = (await listApps(signal)).filter((app) => appMatchesWindowQuery(app, query));
-	if (query.app) {
-		const normalizedApp = normalizeText(query.app);
-		const exact = apps.filter((app) => normalizeText(app.appName) === normalizedApp);
-		if (exact.length > 0) apps = exact;
-	}
-	const roots: HelperWindow[] = [];
-	for (const app of apps) roots.push(...await listWindows(app.pid, signal));
-	return roots;
+	const apps = (await listApps(signal)).filter((app) => appMatchesWindowQuery(app, query));
+	return await collectWindowDetails(apps, config, signal);
 }
 
 async function performListWindows(params: FindParams, signal?: AbortSignal): Promise<AgentToolResult<ListWindowsDetails>> {
@@ -1363,12 +1358,7 @@ async function performListWindows(params: FindParams, signal?: AbortSignal): Pro
 		kind: rawParams.kind,
 	};
 	const config = getComputerUseConfig();
-	const nativeRoots = await rootsForFind(query, signal);
-	const desktopForest = collectWindowDetails(nativeRoots, config).filter((root) => appMatchesWindowQuery({
-		appName: root.app,
-		bundleId: root.bundleId,
-		pid: root.pid,
-	}, query));
+	const desktopForest = await windowDetailsForFind(query, config, signal);
 	const includeBrowserPages = !query.pid && !query.bundleId && (!query.app || normalizeText(query.app) === "browser") && config.browser_use;
 	const browserForest: ListWindowsDetails["windows"] = !includeBrowserPages ? [] : (await listCdpPageContexts().catch(() => []))
 		.map((page) => ({

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -839,27 +839,28 @@ async function resolveTargetByWindowSelector(selector: RootSelector, signal?: Ab
 	}
 
 	const numericWindowId = Number(normalized);
-	if (Number.isInteger(numericWindowId) && numericWindowId > 0) {
-		const apps = await listApps(signal);
-		for (const app of apps) {
-			const windows = await listWindows(app.pid, signal);
-			const match = windows.find((window) => window.windowId === numericWindowId);
-			if (match) {
-				assertBrowserUseAllowed(app);
-				const resolved = toResolvedTarget(app, match);
-				setCurrentTarget(resolved);
-				return resolved;
-			}
-		}
-		throw new Error(`Window id '${numericWindowId}' was not found. Call find_roots again and choose a current window.`);
-	}
-
 	if (normalized.startsWith("@r")) {
 		throw new Error(`Root ref '${normalized}' is not available in this session. Call find_roots first.`);
 	}
 
 	const config = getComputerUseConfig();
-	const candidates = await collectWindowDetails(await listApps(signal), config, signal);
+	const candidates = collectWindowDetails(await currentPlatformBackend.listRoots({}, signal), config);
+	if (Number.isInteger(numericWindowId) && numericWindowId > 0) {
+		const match = candidates.find((candidate) => candidate.windowId === numericWindowId);
+		if (!match) {
+			throw new Error(`Window id '${numericWindowId}' was not found. Call find_roots again and choose a current window.`);
+		}
+		const app: HelperApp = { appName: match.app, bundleId: match.bundleId, pid: match.pid };
+		assertBrowserUseAllowed(app);
+		const roots = await listWindows(match.pid, signal);
+		const helperRoot = roots.find((root) => root.windowId === numericWindowId) ?? roots[0];
+		if (!helperRoot) {
+			throw new Error(`Window id '${numericWindowId}' disappeared during resolution. Call find_roots again.`);
+		}
+		const resolved = toResolvedTarget(app, helperRoot);
+		setCurrentTarget(resolved);
+		return resolved;
+	}
 	const query = normalizeText(normalized);
 	const exact = candidates.filter((candidate) => normalizeText(candidate.app) === query || normalizeText(candidate.windowTitle) === query);
 	const fuzzy = exact.length > 0 ? exact : candidates.filter((candidate) => `${normalizeText(candidate.app)} ${normalizeText(candidate.windowTitle)}`.includes(query));
@@ -1294,40 +1295,62 @@ function rootDeltaLines(execution: ExecutionTrace): string[] {
 }
 
 // Side effect: stores stable @r refs for discovered windows in runtimeState.
-async function collectWindowDetails(apps: HelperApp[], config: ReturnType<typeof getComputerUseConfig>, signal?: AbortSignal): Promise<ListWindowsDetails["windows"]> {
-	const perApp = await Promise.all(apps.map(async (app) => ({ app, windows: await listWindows(app.pid, signal) })));
+function collectWindowDetails(roots: HelperWindow[], config: ReturnType<typeof getComputerUseConfig>): ListWindowsDetails["windows"] {
 	const windows: ListWindowsDetails["windows"] = [];
-	for (const { app, windows: appWindows } of perApp) {
-		for (const window of appWindows) {
-			const storedRef = storeWindowRefForAppWindow(app, window);
-			windows.push({
-				app: app.appName,
-				bundleId: app.bundleId,
-				pid: app.pid,
-				kind: window.kind,
-				windowTitle: window.title || "(untitled)",
-				windowId: window.windowId,
-				windowRef: storedRef.ref,
-				nativeWindowRef: window.windowRef,
-				framePoints: window.framePoints,
-				scaleFactor: window.scaleFactor,
-				isMinimized: window.isMinimized,
-				isOnscreen: window.isOnscreen,
-				isMain: window.isMain,
-				isFocused: window.isFocused,
-				isModal: window.isModal,
-				sheetCount: platformRootSheetCount(window),
-				role: window.role,
-				subrole: window.subrole,
-				pairing: platformRootPairing(window),
-				zOrder: window.zOrder,
-				browserUseAllowed: config.browser_use || !currentPlatformBackend.isBrowserApp(app.appName, app.bundleId),
-				score: scoreWindow(window),
-			});
-		}
+	for (const window of roots) {
+		if (!window.pid) continue;
+		const app: HelperApp = {
+			appName: window.appName ?? "Unknown App",
+			bundleId: window.bundleId,
+			pid: window.pid,
+		};
+		const storedRef = storeWindowRefForAppWindow(app, window);
+		windows.push({
+			app: app.appName,
+			bundleId: app.bundleId,
+			pid: app.pid,
+			kind: window.kind,
+			windowTitle: window.title || "(untitled)",
+			windowId: window.windowId,
+			windowRef: storedRef.ref,
+			nativeWindowRef: window.windowRef,
+			framePoints: window.framePoints,
+			scaleFactor: window.scaleFactor,
+			isMinimized: window.isMinimized,
+			isOnscreen: window.isOnscreen,
+			isMain: window.isMain,
+			isFocused: window.isFocused,
+			isModal: window.isModal,
+			sheetCount: platformRootSheetCount(window),
+			role: window.role,
+			subrole: window.subrole,
+			pairing: platformRootPairing(window),
+			zOrder: window.zOrder,
+			browserUseAllowed: config.browser_use || !currentPlatformBackend.isBrowserApp(app.appName, app.bundleId),
+			score: scoreWindow(window),
+		});
 	}
 	windows.sort((a, b) => b.score - a.score || a.app.localeCompare(b.app) || a.windowTitle.localeCompare(b.windowTitle));
 	return windows;
+}
+
+async function rootsForFind(query: FindParams, signal?: AbortSignal): Promise<HelperWindow[]> {
+	if (Number.isFinite(query.pid)) {
+		return await currentPlatformBackend.listRoots({ pid: query.pid }, signal);
+	}
+	if (!query.app && !query.bundleId) {
+		return await currentPlatformBackend.listRoots({}, signal);
+	}
+
+	let apps = (await listApps(signal)).filter((app) => appMatchesWindowQuery(app, query));
+	if (query.app) {
+		const normalizedApp = normalizeText(query.app);
+		const exact = apps.filter((app) => normalizeText(app.appName) === normalizedApp);
+		if (exact.length > 0) apps = exact;
+	}
+	const roots: HelperWindow[] = [];
+	for (const app of apps) roots.push(...await listWindows(app.pid, signal));
+	return roots;
 }
 
 async function performListWindows(params: FindParams, signal?: AbortSignal): Promise<AgentToolResult<ListWindowsDetails>> {
@@ -1339,9 +1362,13 @@ async function performListWindows(params: FindParams, signal?: AbortSignal): Pro
 		pid: Number.isFinite(rawParams.pid) ? Math.trunc(rawParams.pid!) : undefined,
 		kind: rawParams.kind,
 	};
-	const matchingApps = (await listApps(signal)).filter((app) => appMatchesWindowQuery(app, query));
 	const config = getComputerUseConfig();
-	const desktopForest = await collectWindowDetails(matchingApps, config, signal);
+	const nativeRoots = await rootsForFind(query, signal);
+	const desktopForest = collectWindowDetails(nativeRoots, config).filter((root) => appMatchesWindowQuery({
+		appName: root.app,
+		bundleId: root.bundleId,
+		pid: root.pid,
+	}, query));
 	const includeBrowserPages = !query.pid && !query.bundleId && (!query.app || normalizeText(query.app) === "browser") && config.browser_use;
 	const browserForest: ListWindowsDetails["windows"] = !includeBrowserPages ? [] : (await listCdpPageContexts().catch(() => []))
 		.map((page) => ({


### PR DESCRIPTION
## summary

- route only unfiltered `find_roots` discovery through one platform `listRoots({})` call
- preflight broad macos discovery with deduplicated layer-0 and popup-menu window owners before crossing ax
- keep filtered app, bundle, pid, text, browser, ranking, output, selector, and menu-pairing behavior unchanged
- tolerate abandoned helper clients without `sigpipe` termination
- prove the abandoned request completed before asserting helper liveness

this preserves the original implementation and investigation by @basuev in #29, including timofey's authorship on commit `3edf9cf`. the follow-up commit narrows that work to the requested scope.

## validation

- `npm test`
- native arm64 helper build
- live invariant suite with safari and webkit content processes running
- broad discovery completed with 107 apps and 21 returned roots in about 1.9 seconds
- abandoned-client regression completed and the helper remained alive

fixes #28