### PR TITLE
ci: add Dependabot config for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5


### PR DESCRIPTION
Enables Dependabot on this repo. It'll open weekly PRs for dependency updates and GitHub Actions version bumps.

If the weekly cadence is too frequent, `interval: monthly` is a common alternative.