### PR TITLE
ci: add Dependabot config for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,3 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
-  open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for GitHub Actions and npm
- rely on Dependabot’s default pull-request limit to keep the configuration minimal

## Validation

- confirmed the branch is based on current `main`
- `git diff --check` passes
- final change is limited to `.github/dependabot.yml`

Supersedes #43 while preserving its original commit and authorship.