### PR TITLE
chore(core): remove unused bridge symbols

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -11,8 +11,8 @@ import { cdpClickForContext, cdpDragForContext, cdpEvaluateForContext, cdpKeypre
 import { getComputerUseConfig, isBrowserUseEnabled, isHeadlessMode, loadComputerUseConfig } from "./config.ts";
 import { noteAfterAct, noteFromLook, noteRegionKeyForRef, renderNote, type WindowNote } from "./note.ts";
 import { foldToBudget, graftScopedOutline, nodeByRef, outlineNodeLabel, outlineNodePath, rankedTextMatch, restoreOutline, searchOutline, searchOutlineRanked, serializeOutline, serializeOutlineNodeShallow, serializeOutlineSearchMatch, type LookResponse, type Outline, type OutlineChange, type OutlineNode, type OutlineSearchMatch, type SerializedOutline, type SerializedOutlineNode, type SerializedOutlineSearchMatch } from "./outline.ts";
-import { applyOutputEnvelope, boundToolError, clearStoredOutputs, OUTPUT_PAGE_BYTES, readStoredOutput, UI_TEXT_PAGE_CHARS } from "./output.ts";
-import { AGENT_TOOL_NAMES, type ActParams, type EvaluateBrowserParams, type ExpandUiParams, type ImageMode, type InspectUiParams, type LaunchBrowserParams, type FindParams, type MouseButtonName, type NavigateBrowserParams, type ObserveParams, type ObserveTargetParams, type ReadTextParams, type RootSelector, type SearchUiParams, type StateTargetParams, type UiAction, type WaitForParams } from "./contract.ts";
+import { applyOutputEnvelope, boundToolError, clearStoredOutputs, readStoredOutput, UI_TEXT_PAGE_CHARS } from "./output.ts";
+import { AGENT_TOOL_NAMES, type ActParams, type EvaluateBrowserParams, type ExpandUiParams, type ImageMode, type InspectUiParams, type LaunchBrowserParams, type FindParams, type NavigateBrowserParams, type ObserveParams, type ObserveTargetParams, type ReadTextParams, type RootSelector, type SearchUiParams, type UiAction, type WaitForParams } from "./contract.ts";
 import { toFiniteNumber } from "./platform/coerce.ts";
 import { currentPlatformBackend } from "./platform/index.ts";
 import type { FramePoints, HelperActPerformed, HelperActResult, NativeInputDelivery, PlatformActRequest, PlatformApp as HelperApp, PlatformDiagnostics, PlatformFrontmostResult as FrontmostResult, PlatformRoot as HelperWindow } from "./platform/types.ts";
@@ -271,9 +271,7 @@ const CURRENT_TARGET_GONE_ERROR =
 const COMMAND_TIMEOUT_MS = 15_000;
 const LOOK_TIMEOUT_MS = 33_000;
 
-const SCREENSHOT_TIMEOUT_MS = 25_000;
 const ACTION_SETTLE_MS = 280;
-const DEFAULT_WAIT_MS = 1_000;
 
 const BROWSER_CONTEXT_PREFIX = "browser:";
 const MANAGED_BROWSER_READY_TIMEOUT_MS = 15_000;
@@ -340,10 +338,6 @@ export async function shutdownComputerUseSession(): Promise<void> {
 	runtimeState.helperDiagnostics = undefined;
 	runtimeState.lastPermissionCheckAt = 0;
 	await currentPlatformBackend.shutdown?.();
-}
-
-function normalizeError(error: unknown): Error {
-	return error instanceof Error ? error : new Error(String(error));
 }
 
 function currentRuntimeMode(): ExecutionVariant {
@@ -442,10 +436,6 @@ function normalizeText(value: string | undefined): string {
 	return (value ?? "").trim().toLowerCase();
 }
 
-function toOptionalString(value: unknown): string | undefined {
-	return typeof value === "string" ? value : undefined;
-}
-
 function toBoolean(value: unknown): boolean {
 	return value === true;
 }
@@ -473,10 +463,6 @@ function validateStateId(stateId?: string): CurrentCapture {
 		throw new Error("The latest state belongs to a different window. Call observe_ui for the target window and retry.");
 	}
 	return state.currentCapture;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
 }
 
 function formatOutlineNodeLabel(node: OutlineNode): string {
@@ -542,15 +528,6 @@ function currentTargetOrThrow(): CurrentTarget {
 
 function emptyActivation(): ActivationFlags {
 	return { activated: false, unminimized: false, raised: false };
-}
-
-async function isExecutable(filePath: string): Promise<boolean> {
-	try {
-		await access(filePath, fsConstants.X_OK);
-		return true;
-	} catch {
-		return false;
-	}
 }
 
 async function ensureReady(ctx: ExtensionContext, signal?: AbortSignal): Promise<void> {
@@ -628,15 +605,6 @@ function formatWindowLine(window: ListWindowsDetails["windows"][number]): string
 
 async function getFrontmost(signal?: AbortSignal): Promise<FrontmostResult> {
 	return await currentPlatformBackend.getFrontmost(signal);
-}
-
-async function focusControlledWindow(target: ResolvedTarget, signal?: AbortSignal): Promise<void> {
-	const result = await currentPlatformBackend.focusWindow(nativeWindowRequest(target), signal);
-	if (!toBoolean(result?.focused)) {
-		throw new Error(
-			`Unable to focus controlled window '${target.windowTitle}' before input${result?.reason ? `: ${result.reason}` : "."}`,
-		);
-	}
 }
 
 function assertBrowserUseAllowed(target: { appName: string; bundleId?: string }): void {
@@ -873,25 +841,6 @@ async function resolveTargetByWindowSelector(selector: RootSelector, signal?: Ab
 	return resolved;
 }
 
-async function selectWindowIfProvided(selector: RootSelector | undefined, signal?: AbortSignal): Promise<void> {
-	if (!normalizeWindowSelector(selector)) return;
-	const state = operationState();
-	const previous = state.currentTarget;
-	const selected = await resolveTargetByWindowSelector(selector!, signal);
-	const changedWindow =
-		!previous ||
-		previous.pid !== selected.pid ||
-		(previous.windowId > 0 && selected.windowId > 0 ? previous.windowId !== selected.windowId : previous.windowRef !== selected.windowRef);
-	if (changedWindow) {
-		state.currentCapture = undefined;
-		state.currentLook = undefined;
-		state.currentOutline = undefined;
-		delete state.currentNote;
-		state.resourceKey = undefined;
-		state.epoch = undefined;
-	}
-}
-
 function shouldPreferForegroundModalWindow(current: HelperWindow, candidate: HelperWindow): boolean {
 	if (candidate.windowId === current.windowId && candidate.windowRef === current.windowRef) return false;
 	if (!candidate.isOnscreen || candidate.isMinimized) return false;
@@ -1035,10 +984,6 @@ function noteWindowForTarget(target: ResolvedTarget | CurrentTarget, look?: Look
 		pairing: look?.window.metadata?.pairing && typeof look.window.metadata.pairing === "object" ? (look.window.metadata.pairing as { confidence?: "exact" | "high" | "low" }).confidence : undefined,
 		pairingScore: look?.window.metadata?.pairing && typeof look.window.metadata.pairing === "object" ? (look.window.metadata.pairing as { score?: number }).score : undefined,
 	};
-}
-
-function actTargetPublicRef(params: { ref?: string }): string | undefined {
-	return trimOrUndefined(params.ref);
 }
 
 async function captureCurrentTarget(signal?: AbortSignal, readText: "auto" | "always" | "never" = "auto", maxDimension = AUTO_IMAGE_MAX_DIMENSION, targetOverride?: ResolvedTarget, includeImage = true): Promise<CaptureResult> {
@@ -1790,8 +1735,8 @@ async function performExpandUi(params: ExpandUiParams, signal?: AbortSignal): Pr
 	return { content: [{ type: "text", text: `${formatOutlineNodeLabel(target)}\npath: ${outlineNodePath(target)}\n\n${folded.text}` }], details };
 }
 
-/** Pure cached-outline inspection unless a window selector is supplied. */
-async function performInspectUi(params: InspectUiParams, signal?: AbortSignal): Promise<AgentToolResult<OutlineToolDetails>> {
+/** Pure cached-outline inspection. */
+async function performInspectUi(params: InspectUiParams): Promise<AgentToolResult<OutlineToolDetails>> {
 	const state = operationState();
 	const outline = currentOutlineOrThrow(params.stateId);
 	const ref = trimOrUndefined(params.ref);
@@ -1905,7 +1850,7 @@ async function performDesktopTransaction(params: ActParams, actions: UiAction[],
 		const execution = await dispatchUiTransaction(actions, target, look, headless, signal);
 		const executedActions = actions.slice(0, execution.actionCount ?? actions.length);
 		if (condition) {
-			const { text: expectedText, role: expectedRole, value: expectedValue, scopeRef, scopeExact, gone, timeoutMs } = condition;
+			const { text: expectedText, role: expectedRole, value: expectedValue, scopeExact, gone, timeoutMs } = condition;
 			const beforePresent = outlineConditionPresent(look.parsedOutline!, condition);
 			const desiredWasPreexisting = beforePresent !== gone;
 			const verification = await currentPlatformBackend.waitFor({

--- a/src/platform/macos/helper.ts
+++ b/src/platform/macos/helper.ts
@@ -137,7 +137,6 @@ export async function runProcess(
 }
 
 export class MacosHelperClient {
-	private helperInstallChecked = false;
 	private daemonAvailable = false;
 	private requestSequence = 0;
 	private diagnosticsCache?: PlatformDiagnostics;
@@ -152,7 +151,6 @@ export class MacosHelperClient {
 		// agent process's hot path. Protocol compatibility is checked against the
 		// live daemon immediately afterwards.
 		if (await isExecutable(HELPER_APP_EXECUTABLE_PATH)) {
-			this.helperInstallChecked = true;
 			return;
 		}
 
@@ -162,7 +160,6 @@ export class MacosHelperClient {
 			ELECTRON_RUN_AS_NODE: "1",
 			BUN_BE_BUN: "1",
 		});
-		this.helperInstallChecked = true;
 
 		if (!(await isExecutable(HELPER_APP_EXECUTABLE_PATH))) {
 			throw new Error(`Failed to install pi-computer-use helper app at ${HELPER_APP_PATH}.`);

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -144,7 +144,6 @@ export interface PlatformObserveRequest {
 	includeImage?: boolean;
 }
 
-type PlatformActAction = "press" | "click" | "setText" | "typeText" | "keypress" | "scroll" | "drag" | "moveMouse";
 export type PlatformActTarget = { ref: string } | { x: number; y: number } | { focus: PlatformPoint };
 type PlatformDeliveryPolicy = "ax_only" | "background" | "default" | "foreground";
 type PlatformMouseButton = "left" | "right" | "middle";


### PR DESCRIPTION
## Summary

- remove unused imports, constants, helpers, and callback parameters from the shared computer-use bridge
- remove an unused macOS helper bookkeeping field
- remove an unused platform action type alias
- preserve the public type re-exports and runtime behavior

## Why

A strict TypeScript unused-symbol pass identified implementation leftovers that were no longer referenced. Keeping them made the shared bridge harder to audit and suggested behavior that no longer existed, including an obsolete window-selection helper.

## Impact

No public API or runtime behavior changes. The diff removes 64 lines across three shared files.

## Validation

- `tsc -p tsconfig.json --noUnusedLocals --noUnusedParameters --pretty false`
- `tsc -p tsconfig.json --pretty false`
- `npm run test:schema`
- `npm run test:output`
- `npm run test:lifecycle`
- `npm run test:runtime`
- `npm run test:platform`
- `npm run test:signing`
- `npm run test:macos-path`
- `git diff --check`
