### PR TITLE
fix(windows): honor helper path override

### DIFF
--- a/scripts/check-platform-windows.mjs
+++ b/scripts/check-platform-windows.mjs
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { platformBackendForRuntime } from "../src/platform/index.ts";
 import { assertPlatformArchitecture, PLATFORM_ARCHITECTURE_VERSION, REQUIRED_PLATFORM_INVARIANTS } from "../src/platform/architecture.ts";
+
+const helperOverride = "/tmp/custom-windows-bridge.exe";
+process.env.PI_COMPUTER_USE_WINDOWS_HELPER_PATH = helperOverride;
+const [{ platformBackendForRuntime }, { WINDOWS_HELPER_PATH }] = await Promise.all([
+	import("../src/platform/index.ts"),
+	import("../src/platform/windows/helper.ts"),
+]);
+
+assert.equal(WINDOWS_HELPER_PATH, helperOverride);
 
 const win = platformBackendForRuntime("win32");
 assert.equal(win.name, "windows");

--- a/src/platform/windows/helper.ts
+++ b/src/platform/windows/helper.ts
@@ -12,7 +12,7 @@ const HELPER_SETUP_TIMEOUT_MS = 60_000;
 const COMMAND_TIMEOUT_MS = 15_000;
 
 export const WINDOWS_HELPER_PROTOCOL_VERSION = 4;
-export const WINDOWS_HELPER_PATH = path.join(os.homedir(), ".pi", "agent", "helpers", "pi-computer-use", "windows-bridge.exe");
+export const WINDOWS_HELPER_PATH = process.env.PI_COMPUTER_USE_WINDOWS_HELPER_PATH || path.join(os.homedir(), ".pi", "agent", "helpers", "pi-computer-use", "windows-bridge.exe");
 
 interface Pending<T> {
 	resolve(value: T): void;


### PR DESCRIPTION
## summary

- make the windows runtime client honor `PI_COMPUTER_USE_WINDOWS_HELPER_PATH`
- cover the override in the existing windows platform test

## root cause

setup installed the helper at the configured path, but runtime always checked and spawned the default path.

## validation

- `npm run typecheck`
- `npm run test:platform`
- `npm run test:windows-scripts`
- `git diff --check`

closes #56
