### PR TITLE
fix(macos): preserve window action grounding

### DIFF
--- a/native/macos/bridge.swift
+++ b/native/macos/bridge.swift
@@ -3136,6 +3136,13 @@ final class Bridge {
 
 					let filter = SCContentFilter(desktopIndependentWindow: window)
 					let config = SCStreamConfiguration()
+					// SCScreenshotManager always renders at the configured dimensions;
+					// SCStreamConfiguration's defaults are a display-sized 1920x1080.
+					// Size single-window captures to the source window so screenshot
+					// pixels and accessibility geometry share one coordinate space.
+					let scale = displayScaleFactor(for: window.frame)
+					config.width = max(1, Int((window.frame.width * scale).rounded()))
+					config.height = max(1, Int((window.frame.height * scale).rounded()))
 					config.showsCursor = false
 					config.ignoreShadowsSingleWindow = true
 

--- a/native/macos/bridge.swift
+++ b/native/macos/bridge.swift
@@ -3136,10 +3136,7 @@ final class Bridge {
 
 					let filter = SCContentFilter(desktopIndependentWindow: window)
 					let config = SCStreamConfiguration()
-					// SCScreenshotManager always renders at the configured dimensions;
-					// SCStreamConfiguration's defaults are a display-sized 1920x1080.
-					// Size single-window captures to the source window so screenshot
-					// pixels and accessibility geometry share one coordinate space.
+					// Avoid ScreenCaptureKit's default 1920x1080 canvas for window captures.
 					let scale = displayScaleFactor(for: window.frame)
 					config.width = max(1, Int((window.frame.width * scale).rounded()))
 					config.height = max(1, Int((window.frame.height * scale).rounded()))

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { noteAfterAct, noteFromLook } from "../src/note.ts";
 import { countOutlineNodes, foldToBudget, graftScopedOutline, nodeByRef, parseLookResponse } from "../src/outline.ts";
+import { shouldPreferForegroundModalWindow } from "../src/root-selection.ts";
 
 const root = path.resolve(new URL("..", import.meta.url).pathname);
 const swift = fs.readFileSync(path.join(root, "native/macos/bridge.swift"), "utf8");
@@ -105,6 +106,32 @@ check("INV-5 listRoots seam stays platform-neutral", () => {
 	assert(srcFiles.some(([, text]) => /interface PlatformRoot[\s\S]*metadata\?: Record<string, unknown>/.test(text)), "PlatformRoot lacks metadata escape hatch");
 	assert(!srcFiles.some(([, text]) => /interface PlatformRoot[\s\S]*\bpairing:/.test(text)), "PlatformRoot must not require pairing");
 	assert(!srcFiles.some(([, text]) => /interface PlatformRoot[\s\S]*\bsheetCount:/.test(text)), "PlatformRoot must not require sheetCount");
+});
+
+check("explicit root is not replaced by a modal window behind it", () => {
+	const root = (overrides) => ({
+		windowId: 1,
+		windowRef: "w1",
+		title: "Input",
+		zOrder: 5,
+		isModal: false,
+		isFocused: false,
+		isMain: true,
+		isMinimized: false,
+		isOnscreen: true,
+		...overrides,
+	});
+	const current = root({});
+	const behindModal = root({ windowId: 2, windowRef: "w2", title: "Main", zOrder: 20, isModal: true });
+	const foregroundModal = root({ windowId: 3, windowRef: "w3", title: "Prompt", zOrder: 2, isModal: true });
+	assert(!shouldPreferForegroundModalWindow(current, behindModal), "modal root behind the explicit target was promoted");
+	assert(shouldPreferForegroundModalWindow(current, foregroundModal), "foreground modal root was not promoted");
+});
+
+check("macOS ScreenCaptureKit config sizes window screenshots", () => {
+	const captureFunction = swift.slice(swift.indexOf("private func captureWindow"), swift.indexOf("private func jpegData"));
+	assert(/config\.width\s*=/.test(captureFunction), "captureWindow does not set SCStreamConfiguration.width");
+	assert(/config\.height\s*=/.test(captureFunction), "captureWindow does not set SCStreamConfiguration.height");
 });
 
 function enclosingFunctionName(text, index) {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -18,6 +18,7 @@ import { currentPlatformBackend } from "./platform/index.ts";
 import type { FramePoints, HelperActPerformed, HelperActResult, NativeInputDelivery, PlatformActRequest, PlatformApp as HelperApp, PlatformDiagnostics, PlatformFrontmostResult as FrontmostResult, PlatformRoot as HelperWindow } from "./platform/types.ts";
 import type { PermissionStatus } from "./permissions.ts";
 import { ResourceScheduler } from "./runtime.ts";
+import { scoreWindow, shouldPreferForegroundModalWindow } from "./root-selection.ts";
 import { SavedStates, type CurrentCapture, type CurrentTarget, type OperationState } from "./state.ts";
 import { changesBetween, renderChanges, stabilizeRefs } from "./view.ts";
 export type { ActParams, EvaluateBrowserParams, ExpandUiParams, ImageMode, InspectUiParams, LaunchBrowserParams, FindParams, MouseButtonName, NavigateBrowserParams, ObserveParams, ObserveTargetParams, ReadTextParams, RootSelector, SearchUiParams, StateTargetParams, UiAction, WaitForParams } from "./contract.ts";
@@ -711,18 +712,6 @@ function choosePreferredWindow(windows: HelperWindow[], appName: string): Helper
 	return scored[0];
 }
 
-function scoreWindow(window: HelperWindow): number {
-	let score = 0;
-	if (window.isModal) score += 180;
-	if (window.isFocused) score += 100;
-	if (window.isMain) score += 80;
-	if (!window.isMinimized) score += 40;
-	if (window.isOnscreen) score += 20;
-	if (window.windowId && window.windowId > 0) score += 10;
-	if (window.title.trim().length > 0) score += 2;
-	return score;
-}
-
 function summarizeWindowCandidate(window: HelperWindow): string {
 	const flags = [
 		window.isFocused ? "focused" : undefined,
@@ -854,13 +843,6 @@ async function resolveTargetByWindowSelector(selector: RootSelector, signal?: Ab
 	const resolved = toResolvedTarget(app, helperRoot);
 	setCurrentTarget(resolved);
 	return resolved;
-}
-
-function shouldPreferForegroundModalWindow(current: HelperWindow, candidate: HelperWindow): boolean {
-	if (candidate.windowId === current.windowId && candidate.windowRef === current.windowRef) return false;
-	if (!candidate.isOnscreen || candidate.isMinimized) return false;
-	if (candidate.isModal) return scoreWindow(candidate) >= scoreWindow(current);
-	return false;
 }
 
 async function resolveCurrentTarget(signal?: AbortSignal): Promise<ResolvedTarget> {

--- a/src/root-selection.ts
+++ b/src/root-selection.ts
@@ -19,9 +19,7 @@ export function scoreWindow(window: RankedRoot): number {
 export function shouldPreferForegroundModalWindow(current: RankedRoot, candidate: RankedRoot): boolean {
 	if (candidate.windowId === current.windowId && candidate.windowRef === current.windowRef) return false;
 	if (!candidate.isOnscreen || candidate.isMinimized || !candidate.isModal) return false;
-	// Preserve the explicitly observed root unless a modal is actually in front
-	// of it. Some apps expose their long-lived main window as AXDialog; modality
-	// alone must not redirect a state-owned action to that background window.
+	// AXDialog can describe a background main window, so modality alone is insufficient.
 	const candidateIsInFront = candidate.isFocused || candidate.zOrder < current.zOrder;
 	return candidateIsInFront && scoreWindow(candidate) >= scoreWindow(current);
 }

--- a/src/root-selection.ts
+++ b/src/root-selection.ts
@@ -1,0 +1,27 @@
+import type { PlatformRoot } from "./platform/types.ts";
+
+type RankedRoot = Pick<PlatformRoot,
+	"windowId" | "windowRef" | "isModal" | "isFocused" | "isMain" | "isMinimized" | "isOnscreen" | "zOrder" | "title"
+>;
+
+export function scoreWindow(window: RankedRoot): number {
+	let score = 0;
+	if (window.isModal) score += 180;
+	if (window.isFocused) score += 100;
+	if (window.isMain) score += 80;
+	if (!window.isMinimized) score += 40;
+	if (window.isOnscreen) score += 20;
+	if (window.windowId && window.windowId > 0) score += 10;
+	if (window.title.trim().length > 0) score += 2;
+	return score;
+}
+
+export function shouldPreferForegroundModalWindow(current: RankedRoot, candidate: RankedRoot): boolean {
+	if (candidate.windowId === current.windowId && candidate.windowRef === current.windowRef) return false;
+	if (!candidate.isOnscreen || candidate.isMinimized || !candidate.isModal) return false;
+	// Preserve the explicitly observed root unless a modal is actually in front
+	// of it. Some apps expose their long-lived main window as AXDialog; modality
+	// alone must not redirect a state-owned action to that background window.
+	const candidateIsInFront = candidate.isFocused || candidate.zOrder < current.zOrder;
+	return candidateIsInFront && scoreWindow(candidate) >= scoreWindow(current);
+}


### PR DESCRIPTION
## Summary

Fix macOS window action grounding in two related places:

- preserve an explicitly observed root when a higher-scoring modal-like window is behind it
- size ScreenCaptureKit single-window screenshots from the source frame and backing scale
- add regression coverage for root promotion and capture configuration

This prevents state-owned actions from switching to another same-process window and keeps screenshot pixels aligned with accessibility geometry.

Closes #64.

## User-facing change

Coordinate actions against small or transient macOS windows now stay on the observed window. Long-lived windows exposed as `AXDialog` no longer steal actions merely because modality gives them a higher root score.

Before this change, a 392×173-point Java Input window produced a padded 900×506 screenshot and an action from its state was retargeted to the application's main window. After the change, the same window captures at 784×346 on a 2× display and the action closes the intended Input root.

## Permission and compatibility impact

No browser or strict-AX behavior changes. No new permissions are required. Rebuilding a locally signed macOS helper can require macOS to revalidate its existing Accessibility and Screen Recording grants; release-signed upgrades retain the normal stable identity.

## Validation

- `npm test`
- `npm run build:native`
- Existing commit-message check for `origin/main..HEAD`
- Live patched-helper check on the original transient-window fixture:
  - frame: 392×173 points
  - capture: 784×346 pixels
  - scale factor: 2.0
  - action outcome: `worked`
  - root delta: Input root closed
  - remaining Input roots: 0

Cubench was not run because the repository has no local Cubench checkout; the original application fixture was exercised directly through the installed patched helper.
