### PR TITLE
fix(setup-helper): add download timeout to prevent indefinite postinstall hang

### DIFF
--- a/scripts/setup-helper.mjs
+++ b/scripts/setup-helper.mjs
@@ -137,9 +137,6 @@ async function commandOutput(command, commandArgs) {
 	return stdout;
 }
 
-// Hard cap so a stalled GitHub release download aborts instead of hanging the
-// postinstall forever. The helper app is ~0.5 MB, so 120 s is generous even on
-// a poor link — and it beats an indefinite hang that makes `pi update` time out.
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 
 async function downloadFile(url, outputPath) {

--- a/scripts/setup-helper.mjs
+++ b/scripts/setup-helper.mjs
@@ -137,8 +137,13 @@ async function commandOutput(command, commandArgs) {
 	return stdout;
 }
 
+// Hard cap so a stalled GitHub release download aborts instead of hanging the
+// postinstall forever. The helper app is ~0.5 MB, so 120 s is generous even on
+// a poor link — and it beats an indefinite hang that makes `pi update` time out.
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
 async function downloadFile(url, outputPath) {
-	const response = await fetch(url);
+	const response = await fetch(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
 	if (!response.ok) {
 		throw new Error(`HTTP ${response.status} ${response.statusText}`);
 	}
@@ -149,7 +154,7 @@ async function downloadFile(url, outputPath) {
 }
 
 async function releaseChecksums(tag) {
-	const response = await fetch(githubReleaseUrl(tag, "SHA256SUMS"));
+	const response = await fetch(githubReleaseUrl(tag, "SHA256SUMS"), { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
 	if (!response.ok) return new Map();
 	const text = await response.text();
 	const checksums = new Map();


### PR DESCRIPTION
## Problem

`downloadFile()` and `releaseChecksums()` in `scripts/setup-helper.mjs` use bare `fetch()` with **no timeout**:

```js
async function downloadFile(url, outputPath) {
	const response = await fetch(url);   // ← no signal, no timeout
	...
	await pipeline(response.body, createWriteStream(outputPath));  // ← streams forever if stalled
}
```

When the GitHub release download (`pi-computer-use.app.zip`, ~0.5 MB) stalls — e.g. an `SSL_ERROR_SYSCALL` to `github.com:443` — the postinstall **hangs indefinitely**. This makes `pi update --extensions` time out (observed >5 min with no recovery), and because npm's transactional staging is left half-done, it can cascade into `ENOTEMPTY` errors on subsequent installs.

## Fix

Add a `120_000` ms (120 s) hard cap via `AbortSignal.timeout()` to both `fetch()` calls:

```js
const DOWNLOAD_TIMEOUT_MS = 120_000;

const response = await fetch(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
```

The helper app is ~0.5 MB, so 120 s is generous even on a poor link. `AbortSignal.timeout()` also aborts the streaming `response.body`, so a stall mid-download is covered — not just the initial connection. On timeout the postinstall aborts with a clear `TimeoutError` instead of hanging forever.

`AbortSignal.timeout()` is available in Node 18+ (pi runs on Node 24).

## Changes
- `scripts/setup-helper.mjs`: add `DOWNLOAD_TIMEOUT_MS` constant; pass `signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS)` to the `downloadFile()` fetch and the `releaseChecksums()` fetch.

No behavioral change for healthy downloads; only stalls now fail fast instead of hanging.
